### PR TITLE
 6-1: 날짜 지정 루틴 추가 기능 구현 (One-time Routine)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,9 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
+
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
     ksp(libs.room.compiler)

--- a/app/src/main/java/com/example/myroutine/common/AppScaffold.kt
+++ b/app/src/main/java/com/example/myroutine/common/AppScaffold.kt
@@ -143,10 +143,7 @@ fun AppScaffold(onBackPressedDispatcher: OnBackPressedDispatcher) {
                     ) {
                         AddRoutineScreen(
                             onBack = { navController.popBackStack() },
-                            onSave = {
-                                //TODO: 저장 로직 구현
-                                navController.popBackStack()
-                            }
+                            onSave = { navController.popBackStack() }
                         )
                     }
                 }

--- a/app/src/main/java/com/example/myroutine/common/LogWrapper.kt
+++ b/app/src/main/java/com/example/myroutine/common/LogWrapper.kt
@@ -1,0 +1,29 @@
+package com.example.myroutine.common
+
+object LogWrapper {
+    var DEBUG = true // 테스트 환경에서는 false로 설정 가능
+
+    fun d(tag: String, message: String) {
+        if (DEBUG) android.util.Log.d(tag, message)
+    }
+
+    fun w(tag: String, message: String) {
+        if (DEBUG) android.util.Log.w(tag, message)
+    }
+
+    fun i(tag: String, message: String) {
+        if (DEBUG) android.util.Log.i(tag, message)
+    }
+
+    fun e(tag: String, message: String, throwable: Throwable? = null) {
+        if (DEBUG) android.util.Log.e(tag, message, throwable)
+    }
+
+    fun v(tag: String, message: String) {
+        if (DEBUG) android.util.Log.v(tag, message)
+    }
+
+    fun wtf(tag: String, message: String, throwable: Throwable? = null) {
+        if (DEBUG) android.util.Log.wtf(tag, message, throwable)
+    }
+}

--- a/app/src/main/java/com/example/myroutine/data/local/dao/RoutineDao.kt
+++ b/app/src/main/java/com/example/myroutine/data/local/dao/RoutineDao.kt
@@ -13,4 +13,7 @@ interface RoutineDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(routines: List<RoutineItem>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(routine: RoutineItem)
 }

--- a/app/src/main/java/com/example/myroutine/data/local/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/myroutine/data/local/database/AppDatabase.kt
@@ -8,7 +8,7 @@ import com.example.myroutine.data.local.dao.RoutineDao
 import com.example.myroutine.data.local.entity.RoutineCheck
 import com.example.myroutine.data.local.entity.RoutineItem
 
-@Database(entities = [RoutineItem::class, RoutineCheck::class], version = 1)
+@Database(entities = [RoutineItem::class, RoutineCheck::class], version = 2)
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun routineDao(): RoutineDao

--- a/app/src/main/java/com/example/myroutine/data/local/entity/RoutineItem.kt
+++ b/app/src/main/java/com/example/myroutine/data/local/entity/RoutineItem.kt
@@ -24,26 +24,18 @@ data class RoutineItem(
     // 평일/공휴일 구분용, repeatType == WEEKDAY_HOLIDAY 인 경우 사용
     val holidayType: HolidayType? = null,
 
+    val repeatIntervalDays: Int? = null,           // N일 주기
+    val startDate: LocalDate? = null,              // 반복 시작일 기준
+
     // 알람 설정 시간 (nullable이면 알람 없음)
     val alarmTime: LocalTime? = null
-){
-    companion object {
-        fun mock(
-            title: String,
-            isDone: Boolean = false
-        ): RoutineItem {
-            return RoutineItem(
-                title = title,
-                isDone = isDone
-            )
-        }
-    }
-}
+)
 
 enum class RepeatType {
     NONE,           // 반복 없음
     WEEKLY,         // 요일 반복
     ONCE,           // 특정 날짜
+    EVERY_X_DAYS,   // X일마다 반복
     WEEKDAY_HOLIDAY // 평일/공휴일 구분
 }
 

--- a/app/src/main/java/com/example/myroutine/data/local/entity/RoutineItem.kt
+++ b/app/src/main/java/com/example/myroutine/data/local/entity/RoutineItem.kt
@@ -29,7 +29,19 @@ data class RoutineItem(
 
     // 알람 설정 시간 (nullable이면 알람 없음)
     val alarmTime: LocalTime? = null
-)
+){
+    companion object {
+        fun mock(
+            title: String,
+            isDone: Boolean = false
+        ): RoutineItem {
+            return RoutineItem(
+                title = title,
+                isDone = isDone
+            )
+        }
+    }
+}
 
 enum class RepeatType {
     NONE,           // 반복 없음

--- a/app/src/main/java/com/example/myroutine/data/repository/RoutineRepository.kt
+++ b/app/src/main/java/com/example/myroutine/data/repository/RoutineRepository.kt
@@ -4,6 +4,7 @@ import com.example.myroutine.data.local.entity.RoutineItem
 import java.time.LocalDate
 
 interface RoutineRepository {
+    suspend fun insertRoutine(routine: RoutineItem)
     suspend fun getRoutines(): List<RoutineItem>
     suspend fun insertMockDataIfEmpty()
     suspend fun getTodayRoutines(today: LocalDate): List<RoutineItem>

--- a/app/src/main/java/com/example/myroutine/data/repository/RoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/example/myroutine/data/repository/RoutineRepositoryImpl.kt
@@ -15,6 +15,10 @@ class RoutineRepositoryImpl @Inject constructor(
 
     private val TAG = "RoutineRepository"
 
+    override suspend fun insertRoutine(routine: RoutineItem) {
+        routineDao.insert(routine)
+    }
+
     override suspend fun getRoutines(): List<RoutineItem> {
         val routines = routineDao.getAll()
         Log.d(TAG, "Fetched ${routines.size} routines from DB")

--- a/app/src/main/java/com/example/myroutine/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/myroutine/di/DatabaseModule.kt
@@ -25,7 +25,7 @@ object DatabaseModule {
             context,
             AppDatabase::class.java,
             "myroutine-db"
-        ).build()
+        ).fallbackToDestructiveMigration(true).build()
     }
 
     @Provides

--- a/app/src/main/java/com/example/myroutine/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/myroutine/di/RepositoryModule.kt
@@ -1,20 +1,22 @@
 package com.example.myroutine.di
 
+import com.example.myroutine.data.local.dao.RoutineCheckDao
+import com.example.myroutine.data.local.dao.RoutineDao
 import com.example.myroutine.data.repository.RoutineRepository
 import com.example.myroutine.data.repository.RoutineRepositoryImpl
-import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class RepositoryModule {
-
-    @Binds
-    @Singleton
-    abstract fun bindRoutineRepository(
-        impl: RoutineRepositoryImpl
-    ): RoutineRepository
+object RepositoryModule {
+    @Provides
+    fun provideRoutineRepository(
+        routineDao: RoutineDao,
+        checkDao: RoutineCheckDao
+    ): RoutineRepository {
+        return RoutineRepositoryImpl(routineDao, checkDao)
+    }
 }

--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineScreen.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineScreen.kt
@@ -3,9 +3,7 @@ package com.example.myroutine.features.add
 import android.app.TimePickerDialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,14 +11,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -36,193 +32,155 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.myroutine.R
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
-
-data class RoutineInputState(
-    val title: String,
-    val tabIndex: Int,
-    val selectedDateMillis: MutableState<Long?>,
-    val selectedDays: List<String>,
-    val repeatIntervalText: MutableState<String>
-)
 
 @Composable
 fun AddRoutineScreen(
     onBack: () -> Unit,
-    onSave: () -> Unit
+    onSave: () -> Unit,
+    viewModel: AddRoutineViewModel = hiltViewModel()
 ) {
-    var title by remember { mutableStateOf("") }
-    var tabIndex by remember { mutableIntStateOf(1) }
+    val title by viewModel.title.collectAsState()
+    val tabIndex by viewModel.tabIndex.collectAsState()
+    val alarmEnabled by viewModel.alarmEnabled.collectAsState()
+    val alarmTime by viewModel.alarmTime.collectAsState()
 
-    val alarmEnabled = remember { mutableStateOf(false) }
-    val alarmTime = remember { mutableStateOf(LocalTime.now()) }
+    val selectedDate by viewModel.selectedDate.collectAsState()
 
-    val selectedDateMillis = remember { mutableStateOf<Long?>(null) }
-    val selectedDays = remember { mutableStateListOf<String>() }
-    val repeatIntervalText = remember { mutableStateOf("") }
-
-    val snackbarHostState = remember { SnackbarHostState() }
+    val snackBarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
 
-    val inputState = RoutineInputState(
-        title = title,
-        tabIndex = tabIndex,
-        selectedDateMillis = selectedDateMillis,
-        selectedDays = selectedDays,
-        repeatIntervalText = repeatIntervalText
-    )
-
-    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { innerPadding ->
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackBarHostState) }
+    ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(16.dp)
                 .padding(innerPadding)
         ) {
-            TopBar(onBack)
-            TitleInput(title) { title = it }
-            RoutineTabRow(tabIndex) { tabIndex = it }
-            Spacer(modifier = Modifier.height(16.dp))
-            RoutineTabContent(tabIndex, selectedDateMillis, selectedDays, repeatIntervalText)
-            AlarmSettingSection(alarmEnabled, alarmTime)
-            Spacer(modifier = Modifier.weight(1f))
-            SaveButton(
-                inputState = inputState,
-                snackbarHostState = snackbarHostState,
-                coroutineScope = coroutineScope,
-                onSave = onSave
-            )
-        }
-    }
-}
-
-@Composable
-private fun TopBar(onBack: () -> Unit) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        IconButton(onClick = onBack) {
-            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.close))
-        }
-        Text(stringResource(R.string.new_routine), style = MaterialTheme.typography.titleLarge)
-        Spacer(modifier = Modifier.size(48.dp))
-    }
-    Spacer(modifier = Modifier.height(16.dp))
-}
-
-@Composable
-private fun TitleInput(title: String, onTitleChange: (String) -> Unit) {
-    OutlinedTextField(
-        value = title,
-        onValueChange = onTitleChange,
-        label = { Text(stringResource(R.string.routine_title)) },
-        modifier = Modifier.fillMaxWidth()
-    )
-}
-
-@Composable
-private fun RoutineTabRow(selectedIndex: Int, onTabSelected: (Int) -> Unit) {
-    val tabs = listOf(
-        stringResource(R.string.tab_one_time),
-        stringResource(R.string.tab_specific_days),
-        stringResource(R.string.tab_repeat_x_days)
-    )
-    TabRow(selectedTabIndex = selectedIndex, indicator = {}, divider = {}) {
-        tabs.forEachIndexed { index, title ->
-            Tab(
-                selected = selectedIndex == index,
-                onClick = { onTabSelected(index) },
-                modifier = Modifier
-                    .padding(horizontal = 4.dp, vertical = 8.dp)
-                    .background(
-                        color = if (selectedIndex == index) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.colorScheme.surfaceVariant,
-                        shape = MaterialTheme.shapes.medium
-                    )
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            // Top bar
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        Icons.Default.Close,
+                        contentDescription = stringResource(R.string.close),
+                        tint = MaterialTheme.colorScheme.onBackground
+                    )
+                }
                 Text(
-                    text = title,
-                    color = if (selectedIndex == index)
-                        MaterialTheme.colorScheme.onPrimary
-                    else
-                        MaterialTheme.colorScheme.onSurfaceVariant
+                    text = stringResource(R.string.new_routine),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+                Spacer(modifier = Modifier.size(48.dp)) // Close button space
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Title input
+            OutlinedTextField(
+                value = title,
+                onValueChange = { viewModel.onTitleChange(it) },
+                label = { Text(stringResource(R.string.routine_title)) },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            // Tabs
+            TabRow(selectedTabIndex = tabIndex, indicator = {}, divider = {}) {
+                val tabs = listOf(
+                    stringResource(R.string.tab_one_time),
+                    stringResource(R.string.tab_specific_days),
+                    stringResource(R.string.tab_repeat_x_days)
+                )
+                tabs.forEachIndexed { index, tabTitle ->
+                    Tab(
+                        selected = tabIndex == index,
+                        onClick = { viewModel.onTabIndexChange(index) },
+                        modifier = Modifier
+                            .padding(horizontal = 4.dp, vertical = 8.dp)
+                            .background(
+                                color = if (tabIndex == index)
+                                    MaterialTheme.colorScheme.primary
+                                else
+                                    MaterialTheme.colorScheme.surfaceVariant,
+                                shape = MaterialTheme.shapes.medium
+                            )
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                    ) {
+                        Text(
+                            text = tabTitle,
+                            color = if (tabIndex == index)
+                                MaterialTheme.colorScheme.onPrimary
+                            else
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Tab-specific content
+            when (tabIndex) {
+                0 -> OneTimeContent(
+                    selectedDate = selectedDate,
+                    onDateSelected = { viewModel.onSelectedDateChange(it) }
                 )
             }
+
+            AlarmSettingSection(
+                alarmEnabled = alarmEnabled,
+                alarmTime = alarmTime,
+                onAlarmToggle = { viewModel.onAlarmToggle(it) },
+                onAlarmTimeChange = { viewModel.onAlarmTimeChange(it) }
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            val context = LocalContext.current
+
+            // Save button
+            Button(
+                onClick = {
+                    viewModel.saveRoutine(
+                        onSuccess = onSave,
+                        onError = { resId ->
+                            coroutineScope.launch {
+                                snackBarHostState.showSnackbar(
+                                    message = context.getString(resId),
+                                    withDismissAction = true
+                                )
+                            }
+                        }
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.large
+            ) {
+                Text(stringResource(R.string.save))
+            }
         }
-    }
-}
-
-@Composable
-private fun RoutineTabContent(
-    tabIndex: Int,
-    selectedDateMillis: MutableState<Long?>,
-    selectedDays: MutableList<String>,
-    repeatIntervalText: MutableState<String>
-) {
-    when (tabIndex) {
-        0 -> OneTimeContent(selectedDateMillis)
-        1 -> SpecificDaysContent(selectedDays)
-        2 -> RepeatXDaysContent(repeatIntervalText)
-    }
-}
-
-@Composable
-private fun SaveButton(
-    inputState: RoutineInputState,
-    snackbarHostState: SnackbarHostState,
-    coroutineScope: CoroutineScope,
-    onSave: () -> Unit
-) {
-    val toastTitleRequired = stringResource(R.string.toast_title_required)
-    val toastDateRequired = stringResource(R.string.toast_date_required)
-    val toastDayRequired = stringResource(R.string.toast_day_required)
-    val toastRepeatRequired = stringResource(R.string.toast_repeat_required)
-
-    Button(
-        onClick = {
-            val errorMessage = when {
-                inputState.title.isBlank() -> toastTitleRequired
-                inputState.tabIndex == 0 && inputState.selectedDateMillis.value == null -> toastDateRequired
-                inputState.tabIndex == 1 && inputState.selectedDays.isEmpty() -> toastDayRequired
-                inputState.tabIndex == 2 && inputState.repeatIntervalText.value.isBlank() -> toastRepeatRequired
-                else -> null
-            }
-
-            if (errorMessage != null) {
-                coroutineScope.launch {
-                    snackbarHostState.showSnackbar(errorMessage, withDismissAction = true)
-                }
-            } else {
-                onSave()
-            }
-        },
-        modifier = Modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.large
-    ) {
-        Text(stringResource(R.string.save))
     }
 }
 
@@ -230,12 +188,20 @@ private fun SaveButton(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun OneTimeContent(selectedDateMillis: MutableState<Long?>) {
+fun OneTimeContent(
+    selectedDate: LocalDate?,
+    onDateSelected: (LocalDate) -> Unit
+) {
     val datePickerState = rememberDatePickerState()
     val openDialog = remember { mutableStateOf(false) }
 
     LaunchedEffect(datePickerState.selectedDateMillis) {
-        selectedDateMillis.value = datePickerState.selectedDateMillis
+        datePickerState.selectedDateMillis?.let {
+            val localDate = Instant.ofEpochMilli(it)
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate()
+            onDateSelected(localDate)
+        }
     }
 
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -245,114 +211,36 @@ fun OneTimeContent(selectedDateMillis: MutableState<Long?>) {
 
         Text(
             color = MaterialTheme.colorScheme.onBackground,
-            text = datePickerState.selectedDateMillis?.let {
-                val localDate =
-                    Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDate()
-                stringResource(R.string.selected_date, localDate.toString())
-            } ?: stringResource(R.string.no_date_selected))
+            text = selectedDate?.toString() ?: stringResource(R.string.no_date_selected)
+        )
 
         if (openDialog.value) {
-            DatePickerDialog(onDismissRequest = { openDialog.value = false }, confirmButton = {
-                TextButton(onClick = { openDialog.value = false }) {
-                    stringResource(R.string.confirm)
+            DatePickerDialog(
+                onDismissRequest = { openDialog.value = false },
+                confirmButton = {
+                    TextButton(onClick = { openDialog.value = false }) {
+                        Text(stringResource(R.string.confirm))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { openDialog.value = false }) {
+                        Text(stringResource(R.string.cancel))
+                    }
                 }
-            }, dismissButton = {
-                TextButton(onClick = { openDialog.value = false }) {
-                    stringResource(R.string.cancel)
-                }
-            }) {
+            ) {
                 DatePicker(state = datePickerState)
             }
         }
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-fun SpecificDaysContent(selectedDays: MutableList<String>) {
-    val days = listOf(
-        stringResource(R.string.sun),
-        stringResource(R.string.mon),
-        stringResource(R.string.tue),
-        stringResource(R.string.wed),
-        stringResource(R.string.thu),
-        stringResource(R.string.fri),
-        stringResource(R.string.sat)
-    )
-    val excludeHolidays = remember { mutableStateOf(false) }
-
-    Text(
-        stringResource(R.string.repeat),
-        style = MaterialTheme.typography.titleLarge,
-        color = MaterialTheme.colorScheme.onBackground
-    )
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        days.forEach { day ->
-            Box(modifier = Modifier.weight(1f)) {
-                FilterChip(
-                    selected = selectedDays.contains(day),
-                    onClick = {
-                        if (selectedDays.contains(day)) selectedDays.remove(day)
-                        else selectedDays.add(day)
-                    },
-                    label = {
-                        Text(
-                            text = day,
-                            modifier = Modifier.fillMaxWidth(),
-                            textAlign = TextAlign.Center,
-                            maxLines = 1
-                        )
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        }
-    }
-
-
-    Spacer(modifier = Modifier.height(16.dp))
-
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            stringResource(R.string.exclude_holidays),
-            color = MaterialTheme.colorScheme.onBackground
-        )
-        Switch(
-            checked = excludeHolidays.value, onCheckedChange = { excludeHolidays.value = it })
-    }
-
-    if (excludeHolidays.value) {
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = stringResource(R.string.holiday_exclusion_note),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
-        )
-    }
-}
-
-@Composable
-fun RepeatXDaysContent(intervalText: MutableState<String>) {
-    OutlinedTextField(
-        value = intervalText.value,
-        onValueChange = { intervalText.value = it.filter { c -> c.isDigit() } },
-        label = { Text(stringResource(R.string.repeat_every_x_days)) },
-        modifier = Modifier.fillMaxWidth(),
-        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number)
-    )
-}
 
 @Composable
 fun AlarmSettingSection(
-    alarmEnabled: MutableState<Boolean>,
-    alarmTime: MutableState<LocalTime>
+    alarmEnabled: Boolean,
+    alarmTime: LocalTime,
+    onAlarmToggle: (Boolean) -> Unit,
+    onAlarmTimeChange: (LocalTime) -> Unit
 ) {
     val context = LocalContext.current
     val showDialog = remember { mutableStateOf(false) }
@@ -361,8 +249,9 @@ fun AlarmSettingSection(
         Text(
             stringResource(R.string.alarm),
             style = MaterialTheme.typography.titleLarge,
-            color = MaterialTheme.colorScheme.onBackground,
+            color = MaterialTheme.colorScheme.onBackground
         )
+
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
@@ -373,13 +262,15 @@ fun AlarmSettingSection(
                 color = MaterialTheme.colorScheme.onBackground
             )
             Switch(
-                checked = alarmEnabled.value, onCheckedChange = {
-                    alarmEnabled.value = it
+                checked = alarmEnabled,
+                onCheckedChange = {
+                    onAlarmToggle(it)
                     if (it) showDialog.value = true
-                })
+                }
+            )
         }
 
-        if (alarmEnabled.value) {
+        if (alarmEnabled) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -388,8 +279,8 @@ fun AlarmSettingSection(
                 Text(
                     stringResource(
                         R.string.alarm_time,
-                        alarmTime.value.hour,
-                        alarmTime.value.minute
+                        alarmTime.hour,
+                        alarmTime.minute
                     ),
                     color = MaterialTheme.colorScheme.onBackground
                 )
@@ -401,29 +292,30 @@ fun AlarmSettingSection(
 
         if (showDialog.value) {
             TimePickerDialog(
-                context, { _, hour: Int, minute: Int ->
-                    alarmTime.value = LocalTime.of(hour, minute)
+                context,
+                { _, hour: Int, minute: Int ->
+                    onAlarmTimeChange(LocalTime.of(hour, minute))
                     showDialog.value = false
                 },
-                alarmTime.value.hour,
-                alarmTime.value.minute,
+                alarmTime.hour,
+                alarmTime.minute,
                 true
             ).apply {
                 setOnCancelListener {
                     showDialog.value = false
-                    alarmEnabled.value = false
+                    onAlarmToggle(false)
                 }
                 setButton(
                     TimePickerDialog.BUTTON_NEGATIVE,
                     context.getString(R.string.cancel)
                 ) { _, _ ->
                     showDialog.value = false
-                    alarmEnabled.value = false
+                    onAlarmToggle(false)
                 }
             }.show()
         }
-
     }
 }
+
 
 

--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
@@ -1,0 +1,139 @@
+package com.example.myroutine.features.add
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.myroutine.R
+import com.example.myroutine.data.local.entity.HolidayType
+import com.example.myroutine.data.local.entity.RepeatType
+import com.example.myroutine.data.local.entity.RoutineItem
+import com.example.myroutine.data.repository.RoutineRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.LocalTime
+import javax.inject.Inject
+
+@HiltViewModel
+class AddRoutineViewModel @Inject constructor(
+    private val repository: RoutineRepository
+) : ViewModel() {
+
+    private val TAG = "AddRoutineViewModel"
+
+    // StateFlows (입력 상태)
+    private val _title = MutableStateFlow("")
+    val title: StateFlow<String> = _title
+
+    private val _tabIndex = MutableStateFlow(1)
+    val tabIndex: StateFlow<Int> = _tabIndex
+
+    private val _selectedDate = MutableStateFlow<LocalDate?>(null)
+    val selectedDate: StateFlow<LocalDate?> = _selectedDate
+
+    private val _alarmEnabled = MutableStateFlow(false)
+    val alarmEnabled: StateFlow<Boolean> = _alarmEnabled
+
+    private val _alarmTime = MutableStateFlow(LocalTime.now())
+    val alarmTime: StateFlow<LocalTime> = _alarmTime
+
+    // 상태 변경 함수
+    fun onTitleChange(newTitle: String) {
+        Log.d(TAG, "onTitleChange: $newTitle")
+        _title.value = newTitle
+    }
+
+    fun onTabIndexChange(index: Int) {
+        Log.d(TAG, "onTabIndexChange: $index")
+        _tabIndex.value = index
+    }
+
+    fun onSelectedDateChange(date: LocalDate?) {
+        Log.d(TAG, "onSelectedDateChange: $date")
+        _selectedDate.value = date
+    }
+
+
+    fun onAlarmToggle(enabled: Boolean) {
+        Log.d(TAG, "onAlarmToggle: $enabled")
+        _alarmEnabled.value = enabled
+    }
+
+    fun onAlarmTimeChange(time: LocalTime) {
+        Log.d(TAG, "onAlarmTimeChange: $time")
+        _alarmTime.value = time
+    }
+
+    // 저장 처리
+    fun saveRoutine(
+        onSuccess: () -> Unit,
+        onError: (Int) -> Unit
+    ) {
+        val title = _title.value.trim()
+        val tabIndex = _tabIndex.value
+
+        Log.d(TAG, "saveRoutine() called")
+        Log.d(TAG, "Current title: '$title'")
+        Log.d(TAG, "Tab index: $tabIndex")
+
+        if (title.isEmpty()) {
+            Log.w(TAG, "Validation failed: title is empty")
+            onError(R.string.toast_title_required)
+            return
+        }
+
+        val specificDate: LocalDate?
+        val repeatDays: List<Int>?
+        val holidayType: HolidayType?
+        val repeatType: RepeatType
+        val repeatIntervalDays: Int?
+        val startDate: LocalDate?
+
+        when (tabIndex) {
+            0 -> {
+                specificDate = _selectedDate.value
+                if (specificDate == null) {
+                    Log.w(TAG, "Validation failed: specific date not selected")
+                    onError(R.string.toast_date_required)
+                    return
+                }
+                repeatType = RepeatType.ONCE
+                repeatDays = null
+                holidayType = null
+                repeatIntervalDays = null
+                startDate = null
+            }
+
+            else -> {
+                Log.w(TAG, "Validation failed: invalid tab index $tabIndex")
+                specificDate = null
+                repeatDays = null
+                holidayType = null
+                repeatType = RepeatType.NONE
+                repeatIntervalDays = null
+                startDate = null
+            }
+        }
+
+        val routine = RoutineItem(
+            title = title,
+            repeatType = repeatType,
+            specificDate = specificDate,
+            repeatDays = repeatDays,
+            holidayType = holidayType,
+            alarmTime = if (_alarmEnabled.value) _alarmTime.value else null,
+            repeatIntervalDays = repeatIntervalDays,
+            startDate = startDate
+        )
+
+        Log.d(TAG, "Saving routine: $routine")
+
+        viewModelScope.launch {
+            repository.insertRoutine(routine)
+            Log.d(TAG, "Routine saved successfully")
+            onSuccess()
+        }
+    }
+}

--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
@@ -1,9 +1,9 @@
 package com.example.myroutine.features.add
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.myroutine.R
+import com.example.myroutine.common.LogWrapper
 import com.example.myroutine.data.local.entity.HolidayType
 import com.example.myroutine.data.local.entity.RepeatType
 import com.example.myroutine.data.local.entity.RoutineItem
@@ -41,28 +41,28 @@ class AddRoutineViewModel @Inject constructor(
 
     // 상태 변경 함수
     fun onTitleChange(newTitle: String) {
-        Log.d(TAG, "onTitleChange: $newTitle")
+        LogWrapper.d(TAG, "onTitleChange: $newTitle")
         _title.value = newTitle
     }
 
     fun onTabIndexChange(index: Int) {
-        Log.d(TAG, "onTabIndexChange: $index")
+        LogWrapper.d(TAG, "onTabIndexChange: $index")
         _tabIndex.value = index
     }
 
     fun onSelectedDateChange(date: LocalDate?) {
-        Log.d(TAG, "onSelectedDateChange: $date")
+        LogWrapper.d(TAG, "onSelectedDateChange: $date")
         _selectedDate.value = date
     }
 
 
     fun onAlarmToggle(enabled: Boolean) {
-        Log.d(TAG, "onAlarmToggle: $enabled")
+        LogWrapper.d(TAG, "onAlarmToggle: $enabled")
         _alarmEnabled.value = enabled
     }
 
     fun onAlarmTimeChange(time: LocalTime) {
-        Log.d(TAG, "onAlarmTimeChange: $time")
+        LogWrapper.d(TAG, "onAlarmTimeChange: $time")
         _alarmTime.value = time
     }
 
@@ -74,12 +74,12 @@ class AddRoutineViewModel @Inject constructor(
         val title = _title.value.trim()
         val tabIndex = _tabIndex.value
 
-        Log.d(TAG, "saveRoutine() called")
-        Log.d(TAG, "Current title: '$title'")
-        Log.d(TAG, "Tab index: $tabIndex")
+        LogWrapper.d(TAG, "saveRoutine() called")
+        LogWrapper.d(TAG, "Current title: '$title'")
+        LogWrapper.d(TAG, "Tab index: $tabIndex")
 
         if (title.isEmpty()) {
-            Log.w(TAG, "Validation failed: title is empty")
+            LogWrapper.w(TAG, "Validation failed: title is empty")
             onError(R.string.toast_title_required)
             return
         }
@@ -95,7 +95,7 @@ class AddRoutineViewModel @Inject constructor(
             0 -> {
                 specificDate = _selectedDate.value
                 if (specificDate == null) {
-                    Log.w(TAG, "Validation failed: specific date not selected")
+                    LogWrapper.w(TAG, "Validation failed: specific date not selected")
                     onError(R.string.toast_date_required)
                     return
                 }
@@ -107,7 +107,7 @@ class AddRoutineViewModel @Inject constructor(
             }
 
             else -> {
-                Log.w(TAG, "Validation failed: invalid tab index $tabIndex")
+                LogWrapper.w(TAG, "Validation failed: invalid tab index $tabIndex")
                 specificDate = null
                 repeatDays = null
                 holidayType = null
@@ -128,11 +128,11 @@ class AddRoutineViewModel @Inject constructor(
             startDate = startDate
         )
 
-        Log.d(TAG, "Saving routine: $routine")
+        LogWrapper.d(TAG, "Saving routine: $routine")
 
         viewModelScope.launch {
             repository.insertRoutine(routine)
-            Log.d(TAG, "Routine saved successfully")
+            LogWrapper.d(TAG, "Routine saved successfully")
             onSuccess()
         }
     }

--- a/app/src/test/java/com/example/myroutine/AddRoutineViewModelTest.kt
+++ b/app/src/test/java/com/example/myroutine/AddRoutineViewModelTest.kt
@@ -1,0 +1,141 @@
+package com.example.myroutine
+
+import com.example.myroutine.common.LogWrapper
+import com.example.myroutine.data.local.entity.RepeatType
+import com.example.myroutine.data.local.entity.RoutineItem
+import com.example.myroutine.data.repository.RoutineRepository
+import com.example.myroutine.features.add.AddRoutineViewModel
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddRoutineViewModelTest {
+
+    private lateinit var viewModel: AddRoutineViewModel
+    private val repository: RoutineRepository = mockk(relaxed = true)
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        LogWrapper.DEBUG = false
+        Dispatchers.setMain(testDispatcher)
+        viewModel = AddRoutineViewModel(repository)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    /**
+     * 제목이 비어 있을 경우 에러 콜백이 호출되어야 한다.
+     */
+    @Test
+    fun shouldCallErrorCallback_whenTitleIsEmpty() {
+        var errorCalledWith: Int? = null
+        viewModel.onTitleChange("")
+        viewModel.onTabIndexChange(0)
+        viewModel.onSelectedDateChange(LocalDate.now())
+
+        viewModel.saveRoutine(
+            onSuccess = { fail("onSuccess should not be called") },
+            onError = { errorCalledWith = it }
+        )
+
+        assertEquals(R.string.toast_title_required, errorCalledWith)
+    }
+
+    /**
+     * 날짜 지정 탭에서 날짜가 선택되지 않았을 경우 에러 콜백이 호출되어야 한다.
+     */
+    @Test
+    fun shouldCallErrorCallback_whenDateNotSelectedInDateTab() {
+        var errorCalledWith: Int? = null
+        viewModel.onTitleChange("Drink Water")
+        viewModel.onTabIndexChange(0)
+        viewModel.onSelectedDateChange(null)
+
+        viewModel.saveRoutine(
+            onSuccess = { fail("onSuccess should not be called") },
+            onError = { errorCalledWith = it }
+        )
+
+        assertEquals(R.string.toast_date_required, errorCalledWith)
+    }
+
+    /**
+     * 모든 입력이 정상적일 경우 루틴이 저장되고 onSuccess 콜백이 호출되어야 한다.
+     */
+    @Test
+    fun shouldSaveRoutineAndCallOnSuccess_whenInputIsValid() = runTest {
+        val onSuccess = mockk<() -> Unit>(relaxed = true)
+        val onError = mockk<(Int) -> Unit>(relaxed = true)
+
+        viewModel.onTitleChange("Exercise")
+        viewModel.onTabIndexChange(0)
+        viewModel.onSelectedDateChange(LocalDate.of(2025, 6, 17))
+        viewModel.onAlarmToggle(true)
+        viewModel.onAlarmTimeChange(LocalTime.of(7, 30))
+
+        viewModel.saveRoutine(onSuccess = onSuccess, onError = onError)
+        testScheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.insertRoutine(any<RoutineItem>()) }
+        verify(exactly = 1) { onSuccess() }
+        verify(exactly = 0) { onError(any()) }
+    }
+
+    /**
+     * 저장된 RoutineItem의 값이 기대한 값과 일치하는지 검증한다.
+     */
+    @Test
+    fun shouldSaveCorrectRoutineItem_whenInputIsValid() = runTest {
+        // given
+        val slot = slot<RoutineItem>()
+        val title = "운동하기"
+        val date = LocalDate.of(2025, 6, 18)
+        val time = LocalTime.of(6, 0)
+
+        viewModel.onTitleChange(title)
+        viewModel.onTabIndexChange(0)
+        viewModel.onSelectedDateChange(date)
+        viewModel.onAlarmToggle(true)
+        viewModel.onAlarmTimeChange(time)
+
+        // when
+        viewModel.saveRoutine(
+            onSuccess = {},
+            onError = { fail("onError should not be called") }
+        )
+        testScheduler.advanceUntilIdle()
+
+        // then
+        coVerify { repository.insertRoutine(capture(slot)) }
+        val saved = slot.captured
+
+        assertEquals(title, saved.title)
+        assertEquals(RepeatType.ONCE, saved.repeatType)
+        assertEquals(date, saved.specificDate)
+        assertEquals(time, saved.alarmTime)
+        assertEquals(null, saved.repeatDays)
+        assertEquals(null, saved.holidayType)
+        assertEquals(null, saved.repeatIntervalDays)
+        assertEquals(null, saved.startDate)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,12 +6,14 @@ coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
+kotlinxCoroutinesTest = "1.10.2"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
 googleGmsGoogleServices = "4.4.2"
 firebaseFirestore = "25.1.4"
 material = "1.8.2"
+mockk = "1.14.2"
 navigationCompose = "2.9.0"
 hilt = "2.51.1"
 room = "2.7.1"
@@ -30,6 +32,8 @@ room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## 6-1: 날짜 지정 루틴 추가 기능 구현 (One-time Routine)

### 개요  
`AddRoutineScreen` 내 탭 구조 중 첫 번째 탭인 **1회성 루틴(날짜 지정)** 입력 기능을 구현했습니다.  
사용자가 루틴 제목과 날짜, 알람 여부를 입력하면 유효성 검사 후 DB에 저장되며, 에러 발생 시 적절한 리소스를 통해 안내됩니다.

---

### 주요 구현 내용

#### 1. ViewModel 구조 도입
- `AddRoutineViewModel` 신규 작성
- `StateFlow` 기반 상태 관리 도입 (`title`, `tabIndex`, `selectedDate`, `alarmEnabled`, `alarmTime`)
- Hilt를 통한 의존성 주입 구성

#### 2. 루틴 저장 로직 구현
- `saveRoutine()`에서 탭 인덱스에 따른 유효성 검증 수행
  - 제목이 비어 있는 경우: `R.string.toast_title_required` 반환
  - 날짜가 선택되지 않은 경우: `R.string.toast_date_required` 반환
- 유효한 경우 `RoutineItem` 생성 후 Repository를 통해 저장

#### 3. UI 로직 연결
- ViewModel과 UI 간 상태 연결 완료
- 알람 설정 및 날짜 선택 UI 연동 (`TimePickerDialog`, `DatePickerDialog` 등)

#### 4. 에러 처리 및 사용자 피드백
- 에러 발생 시 콜백으로 오류 리소스 전달
- UI에서는 Snackbar를 통해 사용자에게 피드백 표시

---

### 테스트 코드
- `AddRoutineViewModelTest` 클래스 작성
  - 정상 저장 흐름 및 유효성 실패 케이스 커버
  - MockK으로 `RoutineRepository` 모킹 처리
  - `Log` 관련 예외 방지를 위해 테스트 환경에서 `LogWrapper` 적용

---

Closes #16

