### PR TITLE
Feature/6 2 repeat day routine UI

### DIFF
--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
@@ -125,7 +125,7 @@ class AddRoutineViewModel @Inject constructor(
             1 -> {
                 repeatDays = _selectedDays.value
                 if (repeatDays.isEmpty()) {
-                    Log.w(TAG, "Validation failed: repeat days not selected")
+                    L.w(TAG, "Validation failed: repeat days not selected")
                     onError(R.string.toast_day_required)
                     return
                 }

--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.myroutine.features.add
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.myroutine.R
@@ -33,11 +34,17 @@ class AddRoutineViewModel @Inject constructor(
     private val _selectedDate = MutableStateFlow<LocalDate?>(null)
     val selectedDate: StateFlow<LocalDate?> = _selectedDate
 
+    private val _selectedDays = MutableStateFlow<List<Int>>(emptyList())
+    val selectedDays: StateFlow<List<Int>> = _selectedDays
+
     private val _alarmEnabled = MutableStateFlow(false)
     val alarmEnabled: StateFlow<Boolean> = _alarmEnabled
 
     private val _alarmTime = MutableStateFlow(LocalTime.now())
     val alarmTime: StateFlow<LocalTime> = _alarmTime
+
+    private val _excludeHolidays = MutableStateFlow(false)
+    val excludeHolidays: StateFlow<Boolean> = _excludeHolidays
 
     // 상태 변경 함수
     fun onTitleChange(newTitle: String) {
@@ -55,6 +62,15 @@ class AddRoutineViewModel @Inject constructor(
         _selectedDate.value = date
     }
 
+    fun onSelectedDaysChange(days: List<Int>) {
+        Log.d(TAG, "onSelectedDaysChange: $days")
+        _selectedDays.value = days
+    }
+
+    fun onExcludeHolidayToggle(value: Boolean) {
+        Log.d(TAG, "onExcludeHolidayToggle: $value")
+        _excludeHolidays.value = value
+    }
 
     fun onAlarmToggle(enabled: Boolean) {
         L.d(TAG, "onAlarmToggle: $enabled")
@@ -102,6 +118,20 @@ class AddRoutineViewModel @Inject constructor(
                 repeatType = RepeatType.ONCE
                 repeatDays = null
                 holidayType = null
+                repeatIntervalDays = null
+                startDate = null
+            }
+
+            1 -> {
+                repeatDays = _selectedDays.value
+                if (repeatDays.isEmpty()) {
+                    Log.w(TAG, "Validation failed: repeat days not selected")
+                    onError(R.string.toast_day_required)
+                    return
+                }
+                specificDate = null
+                repeatType = if (_excludeHolidays.value) RepeatType.WEEKDAY_HOLIDAY else RepeatType.WEEKLY
+                holidayType = if (_excludeHolidays.value) HolidayType.WEEKDAY else null
                 repeatIntervalDays = null
                 startDate = null
             }

--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
@@ -63,12 +63,12 @@ class AddRoutineViewModel @Inject constructor(
     }
 
     fun onSelectedDaysChange(days: List<Int>) {
-        Log.d(TAG, "onSelectedDaysChange: $days")
+        L.d(TAG, "onSelectedDaysChange: $days")
         _selectedDays.value = days
     }
 
     fun onExcludeHolidayToggle(value: Boolean) {
-        Log.d(TAG, "onExcludeHolidayToggle: $value")
+        L.d(TAG, "onExcludeHolidayToggle: $value")
         _excludeHolidays.value = value
     }
 


### PR DESCRIPTION
# [#6-2] 요일 반복 루틴 UI 구현 #17

이 PR은 특정 요일에 반복되는 루틴 기능과 공휴일 제외 옵션을 지원하기 위한 기능을 추가합니다.  
UI, ViewModel, 단위 테스트가 함께 업데이트되어 해당 기능을 완성합니다.

### 기능 추가: 특정 요일 선택 및 공휴일 제외 옵션  
- `AddRoutineScreen`에 `SpecificDaysContent` 컴포저블을 추가하여 요일 선택과 공휴일 제외 토글 기능을 구현  
  - `FilterChip`를 활용한 요일 선택 UI  
  - `Switch`를 통한 공휴일 제외 옵션 UI  
- `AddRoutineScreen`에 상태 변수 `selectedDays`, `excludeHolidays`를 추가하고, 이를 UI에 반영  

### ViewModel 개선  
- `AddRoutineViewModel`에 `selectedDays`, `excludeHolidays` 상태 및 상태 변경 함수(`onSelectedDaysChange`, `onExcludeHolidayToggle`) 추가  
- `saveRoutine` 함수에서 요일 선택 검증과 공휴일 제외 옵션 반영 로직 추가  
- 사용자의 선택에 따라 `RepeatType`과 `HolidayType`을 적절히 설정  

### 단위 테스트 추가  
- 요일 반복 탭에서 선택된 요일이 없을 때 에러 콜백이 호출되는지 테스트  
- 올바른 요일 선택 시 루틴이 정상 저장되고 성공 콜백이 호출되는지 테스트  

---

close #6-2
