### PR TITLE
Feature/6 3 routine repeat UI

### DIFF
--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineScreen.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineScreen.kt
@@ -206,7 +206,6 @@ fun AddRoutineScreen(
 }
 
 
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OneTimeContent(
@@ -345,7 +344,12 @@ fun RepeatXDaysContent(
 ) {
     OutlinedTextField(
         value = text,
-        onValueChange = { onTextChange(it.filter { c -> c.isDigit() }) },
+        onValueChange = {
+            onTextChange(
+                it.filter { c ->
+                    c.isDigit()
+                })
+        },
         label = { Text(stringResource(R.string.repeat_every_x_days)) },
         modifier = Modifier.fillMaxWidth(),
         keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number)

--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineScreen.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
@@ -44,6 +45,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -67,6 +69,7 @@ fun AddRoutineScreen(
 
     val selectedDate by viewModel.selectedDate.collectAsState()
     val selectedDays by viewModel.selectedDays.collectAsState()
+    val repeatIntervalText by viewModel.repeatIntervalText.collectAsState()
     val excludeHolidays by viewModel.excludeHolidays.collectAsState()
 
     val snackBarHostState = remember { SnackbarHostState() }
@@ -159,6 +162,11 @@ fun AddRoutineScreen(
                     onSelectedDaysChange = { viewModel.onSelectedDaysChange(it) },
                     excludeHolidays = excludeHolidays,
                     onExcludeHolidaysChange = { viewModel.onExcludeHolidayToggle(it) }
+                )
+
+                2 -> RepeatXDaysContent(
+                    text = repeatIntervalText,
+                    onTextChange = { viewModel.onRepeatIntervalChange(it) }
                 )
             }
 
@@ -330,6 +338,19 @@ fun SpecificDaysContent(
     }
 }
 
+@Composable
+fun RepeatXDaysContent(
+    text: String,
+    onTextChange: (String) -> Unit
+) {
+    OutlinedTextField(
+        value = text,
+        onValueChange = { onTextChange(it.filter { c -> c.isDigit() }) },
+        label = { Text(stringResource(R.string.repeat_every_x_days)) },
+        modifier = Modifier.fillMaxWidth(),
+        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Number)
+    )
+}
 
 @Composable
 fun AlarmSettingSection(

--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
@@ -22,7 +22,11 @@ class AddRoutineViewModel @Inject constructor(
     private val repository: RoutineRepository
 ) : ViewModel() {
 
-    private val TAG = "AddRoutineViewModel"
+    companion object {
+        const val TAB_INDEX_SPECIFIC_DATE = 0
+        const val TAB_INDEX_WEEKLY = 1
+        const val TAB_INDEX_EVERY_X_DAYS = 2
+    }
 
     // StateFlows (입력 상태)
     private val _title = MutableStateFlow("")
@@ -51,42 +55,42 @@ class AddRoutineViewModel @Inject constructor(
 
     // 상태 변경 함수
     fun onTitleChange(newTitle: String) {
-        L.d(TAG, "onTitleChange: $newTitle")
+        L.d(this::class.simpleName.toString(), "onTitleChange: $newTitle")
         _title.value = newTitle
     }
 
     fun onTabIndexChange(index: Int) {
-        L.d(TAG, "onTabIndexChange: $index")
+        L.d(this::class.simpleName.toString(), "onTabIndexChange: $index")
         _tabIndex.value = index
     }
 
     fun onSelectedDateChange(date: LocalDate?) {
-        L.d(TAG, "onSelectedDateChange: $date")
+        L.d(this::class.simpleName.toString(), "onSelectedDateChange: $date")
         _selectedDate.value = date
     }
 
     fun onSelectedDaysChange(days: List<Int>) {
-        L.d(TAG, "onSelectedDaysChange: $days")
+        L.d(this::class.simpleName.toString(), "onSelectedDaysChange: $days")
         _selectedDays.value = days
     }
 
     fun onExcludeHolidayToggle(value: Boolean) {
-        L.d(TAG, "onExcludeHolidayToggle: $value")
+        L.d(this::class.simpleName.toString(), "onExcludeHolidayToggle: $value")
         _excludeHolidays.value = value
     }
 
     fun onRepeatIntervalChange(text: String) {
-        L.d(TAG, "onRepeatIntervalChange: $text")
+        L.d(this::class.simpleName.toString(), "onRepeatIntervalChange: $text")
         _repeatIntervalText.value = text
     }
 
     fun onAlarmToggle(enabled: Boolean) {
-        L.d(TAG, "onAlarmToggle: $enabled")
+        L.d(this::class.simpleName.toString(), "onAlarmToggle: $enabled")
         _alarmEnabled.value = enabled
     }
 
     fun onAlarmTimeChange(time: LocalTime) {
-        L.d(TAG, "onAlarmTimeChange: $time")
+        L.d(this::class.simpleName.toString(), "onAlarmTimeChange: $time")
         _alarmTime.value = time
     }
 
@@ -98,12 +102,12 @@ class AddRoutineViewModel @Inject constructor(
         val title = _title.value.trim()
         val tabIndex = _tabIndex.value
 
-        L.d(TAG, "saveRoutine() called")
-        L.d(TAG, "Current title: '$title'")
-        L.d(TAG, "Tab index: $tabIndex")
+        L.d(this::class.simpleName.toString(), "saveRoutine() called")
+        L.d(this::class.simpleName.toString(), "Current title: '$title'")
+        L.d(this::class.simpleName.toString(), "Tab index: $tabIndex")
 
         if (title.isEmpty()) {
-            L.w(TAG, "Validation failed: title is empty")
+            L.w(this::class.simpleName.toString(), "Validation failed: title is empty")
             onError(R.string.toast_title_required)
             return
         }
@@ -116,10 +120,10 @@ class AddRoutineViewModel @Inject constructor(
         val startDate: LocalDate?
 
         when (tabIndex) {
-            0 -> {
+            TAB_INDEX_SPECIFIC_DATE -> {
                 specificDate = _selectedDate.value
                 if (specificDate == null) {
-                    L.w(TAG, "Validation failed: specific date not selected")
+                    L.w(this::class.simpleName.toString(), "Validation failed: specific date not selected")
                     onError(R.string.toast_date_required)
                     return
                 }
@@ -130,10 +134,10 @@ class AddRoutineViewModel @Inject constructor(
                 startDate = null
             }
 
-            1 -> {
+            TAB_INDEX_WEEKLY -> {
                 repeatDays = _selectedDays.value
                 if (repeatDays.isEmpty()) {
-                    L.w(TAG, "Validation failed: repeat days not selected")
+                    L.w(this::class.simpleName.toString(), "Validation failed: repeat days not selected")
                     onError(R.string.toast_day_required)
                     return
                 }
@@ -144,7 +148,7 @@ class AddRoutineViewModel @Inject constructor(
                 startDate = null
             }
 
-            2 -> {
+            TAB_INDEX_EVERY_X_DAYS -> {
                 if (_repeatIntervalText.value.isBlank()) {
                     onError(R.string.toast_repeat_required)
                     return
@@ -165,7 +169,7 @@ class AddRoutineViewModel @Inject constructor(
             }
 
             else -> {
-                L.w(TAG, "Validation failed: invalid tab index $tabIndex")
+                L.w(this::class.simpleName.toString(), "Validation failed: invalid tab index $tabIndex")
                 specificDate = null
                 repeatDays = null
                 holidayType = null
@@ -186,11 +190,11 @@ class AddRoutineViewModel @Inject constructor(
             startDate = startDate
         )
 
-        L.d(TAG, "Saving routine: $routine")
+        L.d(this::class.simpleName.toString(), "Saving routine: $routine")
 
         viewModelScope.launch {
             repository.insertRoutine(routine)
-            L.d(TAG, "Routine saved successfully")
+            L.d(this::class.simpleName.toString(), "Routine saved successfully")
             onSuccess()
         }
     }

--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
@@ -76,7 +76,7 @@ class AddRoutineViewModel @Inject constructor(
     }
 
     fun onRepeatIntervalChange(text: String) {
-        Log.d(TAG, "onRepeatIntervalChange: $text")
+        L.d(TAG, "onRepeatIntervalChange: $text")
         _repeatIntervalText.value = text
     }
 

--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
@@ -37,6 +37,9 @@ class AddRoutineViewModel @Inject constructor(
     private val _selectedDays = MutableStateFlow<List<Int>>(emptyList())
     val selectedDays: StateFlow<List<Int>> = _selectedDays
 
+    private val _repeatIntervalText = MutableStateFlow("")
+    val repeatIntervalText: StateFlow<String> = _repeatIntervalText
+
     private val _alarmEnabled = MutableStateFlow(false)
     val alarmEnabled: StateFlow<Boolean> = _alarmEnabled
 
@@ -70,6 +73,11 @@ class AddRoutineViewModel @Inject constructor(
     fun onExcludeHolidayToggle(value: Boolean) {
         L.d(TAG, "onExcludeHolidayToggle: $value")
         _excludeHolidays.value = value
+    }
+
+    fun onRepeatIntervalChange(text: String) {
+        Log.d(TAG, "onRepeatIntervalChange: $text")
+        _repeatIntervalText.value = text
     }
 
     fun onAlarmToggle(enabled: Boolean) {
@@ -134,6 +142,26 @@ class AddRoutineViewModel @Inject constructor(
                 holidayType = if (_excludeHolidays.value) HolidayType.WEEKDAY else null
                 repeatIntervalDays = null
                 startDate = null
+            }
+
+            2 -> {
+                if (_repeatIntervalText.value.isBlank()) {
+                    onError(R.string.toast_repeat_required)
+                    return
+                }
+
+                val interval = _repeatIntervalText.value.toIntOrNull()
+                if (interval == null || interval <= 0) {
+                    onError(R.string.toast_repeat_required)
+                    return
+                }
+
+                specificDate = null
+                repeatDays = null
+                holidayType = null
+                repeatType = RepeatType.EVERY_X_DAYS
+                startDate = LocalDate.now()
+                repeatIntervalDays = interval
             }
 
             else -> {

--- a/app/src/main/java/com/example/myroutine/features/today/TodayViewModel.kt
+++ b/app/src/main/java/com/example/myroutine/features/today/TodayViewModel.kt
@@ -23,7 +23,6 @@ class TodayViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            repository.insertMockDataIfEmpty()
 
             val today = LocalDate.now()
             val todayRoutines = repository.getTodayRoutines(today)

--- a/app/src/test/java/com/example/myroutine/AddRoutineViewModelTest.kt
+++ b/app/src/test/java/com/example/myroutine/AddRoutineViewModelTest.kt
@@ -279,7 +279,7 @@ class AddRoutineViewModelTest {
         assertEquals("Interval Routine", saved.title)
         assertEquals(RepeatType.EVERY_X_DAYS, saved.repeatType)
         assertEquals(5, saved.repeatIntervalDays)
-        assertEquals(true, saved.alarmTime != null)
+        assertEquals(LocalTime.of(9, 0), saved.alarmTime)
     }
 
     /**

--- a/app/src/test/java/com/example/myroutine/AddRoutineViewModelTest.kt
+++ b/app/src/test/java/com/example/myroutine/AddRoutineViewModelTest.kt
@@ -206,4 +206,105 @@ class AddRoutineViewModelTest {
         assertEquals(null, saved.startDate)
         assertEquals(true, saved.alarmTime != null)
     }
+
+    /**
+     * Given: 제목이 "Interval Routine", 탭 인덱스가 2(특정 일수 반복), 반복 간격 텍스트가 빈 문자열
+     * When: saveRoutine() 호출 시
+     * Then: onError 콜백이 R.string.toast_repeat_required 호출되어야 한다.
+     */
+    @Test
+    fun shouldCallErrorCallback_whenRepeatIntervalIsBlank() {
+        var errorCalledWith: Int? = null
+        viewModel.onTitleChange("Interval Routine")
+        viewModel.onTabIndexChange(2)
+        viewModel.onRepeatIntervalChange("")
+
+        viewModel.saveRoutine(
+            onSuccess = { fail("onSuccess should not be called") },
+            onError = { errorCalledWith = it }
+        )
+
+        assertEquals(R.string.toast_repeat_required, errorCalledWith)
+    }
+
+    /**
+     * Given: 제목이 "Interval Routine", 탭 인덱스가 2, 반복 간격 텍스트가 숫자가 아닌 문자열("abc")
+     * When: saveRoutine() 호출 시
+     * Then: onError 콜백이 R.string.toast_repeat_required 호출되어야 한다.
+     */
+    @Test
+    fun shouldCallErrorCallback_whenRepeatIntervalIsInvalid() {
+        var errorCalledWith: Int? = null
+        viewModel.onTitleChange("Interval Routine")
+        viewModel.onTabIndexChange(2)
+        viewModel.onRepeatIntervalChange("abc")
+
+        viewModel.saveRoutine(
+            onSuccess = { fail("onSuccess should not be called") },
+            onError = { errorCalledWith = it }
+        )
+
+        assertEquals(R.string.toast_repeat_required, errorCalledWith)
+    }
+
+    /**
+     * Given: 제목이 "Interval Routine", 탭 인덱스가 2, 반복 간격 텍스트가 "5" (유효한 숫자),
+     *        알람이 활성화되고 알람 시간이 9:00으로 설정됨
+     * When: saveRoutine() 호출 시
+     * Then: repository.insertRoutine()가 호출되고 onSuccess 콜백이 호출되며,
+     *       저장된 RoutineItem의 필드 값이 올바르게 설정되어야 한다.
+     */
+    @Test
+    fun shouldSaveRoutineAndCallOnSuccess_whenRepeatIntervalIsValid() = runTest {
+        val onSuccess = mockk<() -> Unit>(relaxed = true)
+        val onError = mockk<(Int) -> Unit>(relaxed = true)
+
+        viewModel.onTitleChange("Interval Routine")
+        viewModel.onTabIndexChange(2)
+        viewModel.onRepeatIntervalChange("5")
+        viewModel.onAlarmToggle(true)
+        viewModel.onAlarmTimeChange(LocalTime.of(9, 0))
+
+        viewModel.saveRoutine(onSuccess = onSuccess, onError = onError)
+        testScheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.insertRoutine(any<RoutineItem>()) }
+        verify(exactly = 1) { onSuccess() }
+        verify(exactly = 0) { onError(any()) }
+
+        val slot = slot<RoutineItem>()
+        coVerify { repository.insertRoutine(capture(slot)) }
+        val saved = slot.captured
+
+        assertEquals("Interval Routine", saved.title)
+        assertEquals(RepeatType.EVERY_X_DAYS, saved.repeatType)
+        assertEquals(5, saved.repeatIntervalDays)
+        assertEquals(true, saved.alarmTime != null)
+    }
+
+    /**
+     * Given: 제목이 "Interval Routine No Alarm", 탭 인덱스가 2, 반복 간격 텍스트가 "7",
+     *        알람이 비활성화 상태일 때
+     * When: saveRoutine() 호출 시
+     * Then: 저장된 RoutineItem의 alarmTime 필드가 null 이어야 한다.
+     */
+    @Test
+    fun shouldSaveRoutineWithNullAlarmTime_whenAlarmDisabled_inIntervalTab() = runTest {
+        val onSuccess = mockk<() -> Unit>(relaxed = true)
+        val onError = mockk<(Int) -> Unit>(relaxed = true)
+
+        viewModel.onTitleChange("Interval Routine No Alarm")
+        viewModel.onTabIndexChange(2)
+        viewModel.onRepeatIntervalChange("7")
+        viewModel.onAlarmToggle(false)
+
+        viewModel.saveRoutine(onSuccess = onSuccess, onError = onError)
+        testScheduler.advanceUntilIdle()
+
+        val slot = slot<RoutineItem>()
+        coVerify { repository.insertRoutine(capture(slot)) }
+        val saved = slot.captured
+
+        assertEquals(null, saved.alarmTime)
+    }
 }


### PR DESCRIPTION
# [#6-3] 특정 일수마다 루틴 UI 구현 #18

이 PR은 `AddRoutineScreen`과 `AddRoutineViewModel`에 특정 일수마다 반복되는 루틴 기능을 추가합니다.  
UI, ViewModel 로직, 유효성 검사, 단위 테스트가 포함되어 있습니다.

### 주요 기능: 특정 일수마다 반복 기능 추가

#### UI 변경 사항
- `AddRoutineScreen.kt`에 `RepeatXDaysContent`라는 새로운 컴포저블 함수를 추가하여, 반복 간격(일 단위)을 입력받는 필드를 구현했습니다.  
- 숫자 입력만 가능하도록 제한하고, 키보드 타입을 `KeyboardType.Number`로 설정해 사용자 편의성을 높였습니다.  
- 이 컴포저블을 `AddRoutineScreen`의 탭 레이아웃 내 인덱스 `2` 위치에 통합했습니다.

#### ViewModel 로직 변경 사항
- `AddRoutineViewModel`에 반복 간격 입력 상태를 저장하는 `repeatIntervalText` 상태를 새로 추가했습니다.  
- `saveRoutine()` 함수 내에서 "특정 일수마다 반복" 탭이 선택된 경우, 반복 간격이 비어 있거나 0 이하인 경우 에러 콜백이 호출되도록 유효성 검사를 구현했습니다.  
- 사용자 입력이 변경될 때 상태를 업데이트하고 로그를 남기는 `onRepeatIntervalChange()` 함수를 추가했습니다.

#### 단위 테스트 변경 사항
- `AddRoutineViewModelTest`에 아래 케이스에 대한 테스트를 추가했습니다.  
  - 반복 간격이 비어 있거나 잘못된 경우 에러가 발생하는지 검증  
  - 유효한 반복 간격 입력 시 정상적으로 루틴이 저장되고 성공 콜백이 호출되는지 검증 (알람 활성화/비활성화 포함)

#### 기타 변경 사항
- 코드 정리를 위해 `TodayViewModel`에 있던 미사용 모의 데이터 삽입 로직을 제거했습니다.

---

closes [#18]
