### PR TITLE
feat: 캘린더 기능 구현 및 루틴 필터링 개선

### DIFF
--- a/app/src/main/java/com/example/myroutine/data/local/entity/RoutineItem.kt
+++ b/app/src/main/java/com/example/myroutine/data/local/entity/RoutineItem.kt
@@ -33,11 +33,27 @@ data class RoutineItem(
     companion object {
         fun mock(
             title: String,
-            isDone: Boolean = false
+            id: Int = 0,
+            isDone: Boolean = false,
+            repeatType: RepeatType = RepeatType.NONE,
+            repeatDays: List<Int>? = null,
+            specificDate: LocalDate? = null,
+            holidayType: HolidayType? = null,
+            repeatIntervalDays: Int? = null,
+            startDate: LocalDate? = null,
+            alarmTime: LocalTime? = null
         ): RoutineItem {
             return RoutineItem(
+                id = id,
                 title = title,
-                isDone = isDone
+                isDone = isDone,
+                repeatType = repeatType,
+                repeatDays = repeatDays,
+                specificDate = specificDate,
+                holidayType = holidayType,
+                repeatIntervalDays = repeatIntervalDays,
+                startDate = startDate,
+                alarmTime = alarmTime
             )
         }
     }

--- a/app/src/test/java/com/example/myroutine/CalendarViewModelTest.kt
+++ b/app/src/test/java/com/example/myroutine/CalendarViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.example.myroutine
 
+import com.example.myroutine.data.repository.RoutineRepository
 import com.example.myroutine.features.calendar.CalendarViewModel
+import io.mockk.coEvery
+import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -10,23 +13,27 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
-import org.junit.Before
-import org.junit.Test
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
+import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
 class CalendarViewModelTest {
 
     private lateinit var viewModel: CalendarViewModel
     private val testDispatcher = StandardTestDispatcher()
+    private lateinit var mockRoutineRepository: RoutineRepository
 
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = CalendarViewModel()
+        mockRoutineRepository = mockk<RoutineRepository>()
+        // 기본적으로 getTodayRoutines는 빈 리스트를 반환하도록 설정
+        coEvery { mockRoutineRepository.getTodayRoutines(any()) } returns emptyList()
+        viewModel = CalendarViewModel(mockRoutineRepository)
     }
 
     @After

--- a/app/src/test/java/com/example/myroutine/RoutineFilteringTest.kt
+++ b/app/src/test/java/com/example/myroutine/RoutineFilteringTest.kt
@@ -1,0 +1,78 @@
+package com.example.myroutine
+
+import com.example.myroutine.data.local.entity.RepeatType
+import com.example.myroutine.data.local.entity.RoutineItem
+import com.example.myroutine.data.repository.RoutineRepositoryImpl
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+class RoutineFilteringTest {
+
+    private lateinit var repository: RoutineRepositoryImpl
+
+    @Before
+    fun setup() {
+        // Mocking the DAOs is not strictly necessary for this test, as we are only testing
+        // the `isRoutineApplicableForDate` method, which does not interact with DAOs.
+        // However, if the method were to be moved into a separate utility class, then
+        // this setup would be simpler.
+        repository = RoutineRepositoryImpl(mockk(), mockk())
+    }
+
+    @Test
+    fun `isRoutineApplicableForDate should correctly filter for NONE repeat type`() {
+        val today = LocalDate.of(2024, 7, 7)
+        val routine = RoutineItem.mock("Single Day Routine", specificDate = today, repeatType = RepeatType.NONE)
+
+        assertTrue(repository.isRoutineApplicableForDate(routine, today))
+        assertFalse(repository.isRoutineApplicableForDate(routine, today.plusDays(1)))
+    }
+
+    @Test
+    fun `isRoutineApplicableForDate should correctly filter for ONCE repeat type`() {
+        val today = LocalDate.of(2024, 7, 7)
+        val routine = RoutineItem.mock("Once Routine", specificDate = today, repeatType = RepeatType.ONCE)
+
+        assertTrue(repository.isRoutineApplicableForDate(routine, today))
+        assertFalse(repository.isRoutineApplicableForDate(routine, today.plusDays(1)))
+    }
+
+    @Test
+    fun `isRoutineApplicableForDate should correctly filter for WEEKLY repeat type`() {
+        val monday = LocalDate.of(2024, 7, 8) // Monday
+        val tuesday = LocalDate.of(2024, 7, 9) // Tuesday
+        val routine = RoutineItem.mock("Weekly Routine", repeatDays = listOf(DayOfWeek.MONDAY.value, DayOfWeek.WEDNESDAY.value), repeatType = RepeatType.WEEKLY)
+
+        assertTrue(repository.isRoutineApplicableForDate(routine, monday))
+        assertFalse(repository.isRoutineApplicableForDate(routine, tuesday))
+    }
+
+    @Test
+    fun `isRoutineApplicableForDate should correctly filter for EVERY_X_DAYS repeat type`() {
+        val startDate = LocalDate.of(2024, 7, 1)
+        val routine = RoutineItem.mock("Every 3 Days Routine", startDate = startDate, repeatIntervalDays = 3, repeatType = RepeatType.EVERY_X_DAYS)
+
+        assertTrue(repository.isRoutineApplicableForDate(routine, LocalDate.of(2024, 7, 1))) // Day 0
+        assertFalse(repository.isRoutineApplicableForDate(routine, LocalDate.of(2024, 7, 2))) // Day 1
+        assertFalse(repository.isRoutineApplicableForDate(routine, LocalDate.of(2024, 7, 3))) // Day 2
+        assertTrue(repository.isRoutineApplicableForDate(routine, LocalDate.of(2024, 7, 4))) // Day 3
+        assertTrue(repository.isRoutineApplicableForDate(routine, LocalDate.of(2024, 7, 7))) // Day 6
+    }
+
+    @Test
+    fun `isRoutineApplicableForDate should correctly filter for WEEKDAY_HOLIDAY repeat type`() {
+        val monday = LocalDate.of(2024, 7, 8) // Monday
+        val saturday = LocalDate.of(2024, 7, 6) // Saturday
+        val sunday = LocalDate.of(2024, 7, 7) // Sunday
+        val routine = RoutineItem.mock("Weekday Routine", repeatType = RepeatType.WEEKDAY_HOLIDAY)
+
+        assertTrue(repository.isRoutineApplicableForDate(routine, monday))
+        assertFalse(repository.isRoutineApplicableForDate(routine, saturday))
+        assertFalse(repository.isRoutineApplicableForDate(routine, sunday))
+    }
+}

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,5 +1,5 @@
-refactor: CalendarViewModelTest Mockito에서 MockK로 전환 및 의존성 주입 수정
+feat: RoutineRepositoryImpl 필터링 로직 테스트 추가
 
-`CalendarViewModelTest.kt` 파일에서 Mockito 관련 코드를 MockK로 전환했습니다.
-또한, `CalendarViewModel` 생성자에 `RoutineRepository`의 MockK 객체를 올바르게 주입하도록 `setup()` 메서드를 수정했습니다.
-이는 테스트 코드의 일관성을 유지하고, MockK의 코루틴 테스트 지원 기능을 활용하기 위함입니다.
+`RoutineRepositoryImpl`의 `isRoutineApplicableForDate` 메서드에 대한 단위 테스트를 추가했습니다.
+이 테스트는 `NONE`, `ONCE`, `WEEKLY`, `EVERY_X_DAYS`, `WEEKDAY_HOLIDAY` 등 다양한 반복 유형에 대해 루틴이 특정 날짜에 올바르게 필터링되는지 검증합니다.
+이를 통해 필터링 로직의 정확성을 보장하고 코드의 안정성을 높입니다.

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,14 +1,4 @@
-feat: 캘린더 기능 PR 리뷰 코멘트 반영
+feat: RoutineItem.mock 함수에 반복 관련 필드 추가
 
-이 커밋은 캘린더 기능 PR에 대한 여러 리뷰 코멘트를 반영하여 코드 품질, 가독성 및 국제화를 개선합니다.
-
-- `CalendarScreen.kt` 리팩토링:
-  - `CalendarGrid`에서 사용되지 않는 `displayMonth` 매개변수 제거.
-  - `selectedDate`에 대한 불필요한 null 처리 제거.
-  - `LaunchedEffect`에서 명확성을 위해 명시적인 `else {}` 블록 추가.
-  - 하드코딩된 년/월 표시, 루틴 항목 형식 및 "날짜 선택" 메시지를 더 나은 국제화를 위해 문자열 리소스로 외부화.
-- `CalendarViewModel.kt` 리팩토링:
-  - `init` 블록에서 `_currentMonth` 및 `_selectedDate`의 중복 초기화 제거.
-- `strings.xml` 및 `values-ko/strings.xml` 업데이트:
-  - 캘린더 년/월 형식, 루틴 항목 형식 및 "날짜 선택" 메시지에 대한 새로운 문자열 리소스 추가.
-  - `values/strings.xml`에 영어 번역을, `values-ko/strings.xml`에 한국어 번역을 제공.
+`RoutineItem.mock` 함수에 `repeatType`, `repeatDays`, `specificDate`, `holidayType`, `repeatIntervalDays`, `startDate`, `alarmTime` 파라미터를 추가했습니다.
+이를 통해 테스트 및 목업 데이터 생성 시 다양한 반복 유형을 가진 `RoutineItem` 객체를 유연하게 생성할 수 있습니다.

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,4 +1,6 @@
-refactor: RoutineRepositoryImpl 필터링 로직 분리
+feat: 캘린더 화면에 실제 루틴 데이터 연동 및 UI 업데이트
 
-`RoutineRepositoryImpl.kt`의 `getTodayRoutines` 함수 내에 있던 루틴 필터링 로직을 `isRoutineApplicableForDate`라는 별도의 `internal` 메서드로 분리했습니다.
-이를 통해 코드의 가독성과 재사용성을 높이고, 향후 필터링 로직에 대한 단위 테스트 작성을 용이하게 합니다.
+- `CalendarViewModel`: `RoutineRepository`를 주입받아 선택된 날짜의 루틴 데이터를 가져오고, 루틴 완료 상태를 업데이트하는 로직을 추가했습니다.
+- `CalendarScreen`: 더미 루틴 목록을 `CalendarViewModel`에서 가져온 실제 루틴 데이터로 교체했습니다.
+  - 루틴의 완료 상태와 날짜를 비교하여 완료된 루틴은 초록색, 날짜가 지났지만 완료되지 않은 루틴은 빨간색 배경을 적용하도록 UI를 업데이트했습니다.
+- `strings.xml` 및 `values-ko/strings.xml`: 캘린더 화면에 필요한 새로운 문자열 리소스를 추가하고, 영어 및 한국어 번역을 제공했습니다.

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,6 +1,5 @@
-feat: 캘린더 화면에 실제 루틴 데이터 연동 및 UI 업데이트
+refactor: CalendarViewModelTest Mockito에서 MockK로 전환 및 의존성 주입 수정
 
-- `CalendarViewModel`: `RoutineRepository`를 주입받아 선택된 날짜의 루틴 데이터를 가져오고, 루틴 완료 상태를 업데이트하는 로직을 추가했습니다.
-- `CalendarScreen`: 더미 루틴 목록을 `CalendarViewModel`에서 가져온 실제 루틴 데이터로 교체했습니다.
-  - 루틴의 완료 상태와 날짜를 비교하여 완료된 루틴은 초록색, 날짜가 지났지만 완료되지 않은 루틴은 빨간색 배경을 적용하도록 UI를 업데이트했습니다.
-- `strings.xml` 및 `values-ko/strings.xml`: 캘린더 화면에 필요한 새로운 문자열 리소스를 추가하고, 영어 및 한국어 번역을 제공했습니다.
+`CalendarViewModelTest.kt` 파일에서 Mockito 관련 코드를 MockK로 전환했습니다.
+또한, `CalendarViewModel` 생성자에 `RoutineRepository`의 MockK 객체를 올바르게 주입하도록 `setup()` 메서드를 수정했습니다.
+이는 테스트 코드의 일관성을 유지하고, MockK의 코루틴 테스트 지원 기능을 활용하기 위함입니다.

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,4 +1,4 @@
-feat: RoutineItem.mock 함수에 반복 관련 필드 추가
+refactor: RoutineRepositoryImpl 필터링 로직 분리
 
-`RoutineItem.mock` 함수에 `repeatType`, `repeatDays`, `specificDate`, `holidayType`, `repeatIntervalDays`, `startDate`, `alarmTime` 파라미터를 추가했습니다.
-이를 통해 테스트 및 목업 데이터 생성 시 다양한 반복 유형을 가진 `RoutineItem` 객체를 유연하게 생성할 수 있습니다.
+`RoutineRepositoryImpl.kt`의 `getTodayRoutines` 함수 내에 있던 루틴 필터링 로직을 `isRoutineApplicableForDate`라는 별도의 `internal` 메서드로 분리했습니다.
+이를 통해 코드의 가독성과 재사용성을 높이고, 향후 필터링 로직에 대한 단위 테스트 작성을 용이하게 합니다.


### PR DESCRIPTION
이 Pull Request는 캘린더 기능 구현 및 루틴 필터링 개선을 포함합니다.

**주요 변경 사항:**
- `RoutineItem.mock` 함수에 반복 관련 필드들을 추가하여 테스트 및 목업 데이터 생성 시 유연성을 높였습니다.
- `RoutineRepositoryImpl`에서 `getTodayRoutines` 내의 루틴 필터링 로직을 `isRoutineApplicableForDate` 메서드로 분리하여 코드의 가독성과 재사용성을 높였습니다.
- `CalendarViewModel`에 `RoutineRepository`를 주입하고, `selectedDate` 변경 시 실제 루틴 데이터를 가져오도록 연동했습니다.
- `CalendarScreen`에서 더미 루틴 목록을 실제 데이터로 교체하고, 완료 상태에 따른 UI를 적용했습니다.
- `CalendarViewModelTest`에서 Mockito 관련 코드를 MockK로 전환하고, `CalendarViewModel` 생성자에 `mockRoutineRepository`를 올바르게 주입하도록 수정했습니다.
- `RoutineRepositoryImpl`의 `isRoutineApplicableForDate` 메서드에 대한 단위 테스트인 `RoutineFilteringTest`를 추가했습니다.