### PR TITLE
Feature/report UI

### DIFF
--- a/app/src/main/java/com/example/myroutine/common/AppScaffold.kt
+++ b/app/src/main/java/com/example/myroutine/common/AppScaffold.kt
@@ -45,6 +45,7 @@ import com.example.myroutine.R
 import com.example.myroutine.common.LogTags.MAIN_SCREEN
 import com.example.myroutine.features.add.AddRoutineScreen
 import com.example.myroutine.features.calendar.CalendarScreen
+import com.example.myroutine.features.report.ReportScreen
 import com.example.myroutine.features.today.TodayScreen
 
 
@@ -124,7 +125,7 @@ fun AppScaffold(onBackPressedDispatcher: OnBackPressedDispatcher) {
                         navController,
                         Routes.REPORT
                     ) {
-                        Text("Report")
+                        ReportScreen()
                     }
                 }
                 composable(Routes.SETTINGS) {

--- a/app/src/main/java/com/example/myroutine/common/DateProvider.kt
+++ b/app/src/main/java/com/example/myroutine/common/DateProvider.kt
@@ -1,0 +1,7 @@
+package com.example.myroutine.common
+
+import java.time.LocalDate
+
+interface DateProvider {
+    fun now(): LocalDate
+}

--- a/app/src/main/java/com/example/myroutine/common/DateProviderImpl.kt
+++ b/app/src/main/java/com/example/myroutine/common/DateProviderImpl.kt
@@ -1,0 +1,8 @@
+package com.example.myroutine.common
+
+import java.time.LocalDate
+import javax.inject.Inject
+
+class DateProviderImpl @Inject constructor() : DateProvider {
+    override fun now(): LocalDate = LocalDate.now()
+}

--- a/app/src/main/java/com/example/myroutine/data/local/dao/RoutineCheckDao.kt
+++ b/app/src/main/java/com/example/myroutine/data/local/dao/RoutineCheckDao.kt
@@ -22,4 +22,7 @@ interface RoutineCheckDao {
     @Query("SELECT * FROM RoutineCheck WHERE completeDate = :date")
     suspend fun getChecksForDate(date: LocalDate): List<RoutineCheck>
 
+    @Query("SELECT * FROM RoutineCheck WHERE completeDate BETWEEN :startDate AND :endDate")
+    suspend fun getChecksForPeriod(startDate: LocalDate, endDate: LocalDate): List<RoutineCheck>
+
 }

--- a/app/src/main/java/com/example/myroutine/data/local/dao/RoutineDao.kt
+++ b/app/src/main/java/com/example/myroutine/data/local/dao/RoutineDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.example.myroutine.data.local.entity.RoutineItem
+import java.time.LocalDate
 
 @Dao
 interface RoutineDao {
@@ -16,4 +17,45 @@ interface RoutineDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(routine: RoutineItem)
+
+    @Query("""
+        SELECT * FROM RoutineItem
+        WHERE repeatType IN ('NONE', 'ONCE')
+          AND specificDate BETWEEN :startDate AND :endDate
+    """)
+    suspend fun getNonRepeatingRoutinesInPeriod(startDate: LocalDate, endDate: LocalDate): List<RoutineItem>
+
+    @Query("""
+        SELECT * FROM RoutineItem
+        WHERE repeatType = 'WEEKLY'
+          AND startDate <= :date
+          AND (repeatDays & 
+            CASE strftime('%w', :date)
+                WHEN '0' THEN 64
+                WHEN '1' THEN 1
+                WHEN '2' THEN 2
+                WHEN '3' THEN 4
+                WHEN '4' THEN 8
+                WHEN '5' THEN 16
+                WHEN '6' THEN 32
+            END
+          ) != 0
+    """)
+    suspend fun getWeeklyRoutinesByDate(date: LocalDate): List<RoutineItem>
+
+    @Query("""
+        SELECT * FROM RoutineItem
+        WHERE repeatType = 'EVERY_X_DAYS'
+          AND startDate <= :date
+          AND ((julianday(:date) - julianday(startDate)) % repeatIntervalDays) = 0
+    """)
+    suspend fun getEveryXDaysRoutinesByDate(date: LocalDate): List<RoutineItem>
+
+    @Query("""
+        SELECT * FROM RoutineItem
+        WHERE repeatType = 'WEEKDAY_HOLIDAY'
+          AND startDate <= :date
+          AND strftime('%w', :date) NOT IN ('0', '6')
+    """)
+    suspend fun getWeekdayHolidayRoutinesByDate(date: LocalDate): List<RoutineItem>
 }

--- a/app/src/main/java/com/example/myroutine/data/repository/RoutineRepository.kt
+++ b/app/src/main/java/com/example/myroutine/data/repository/RoutineRepository.kt
@@ -1,5 +1,6 @@
 package com.example.myroutine.data.repository
 
+import com.example.myroutine.data.local.entity.RoutineCheck
 import com.example.myroutine.data.local.entity.RoutineItem
 import java.time.LocalDate
 
@@ -9,6 +10,11 @@ interface RoutineRepository {
     suspend fun insertMockDataIfEmpty()
     suspend fun getTodayRoutines(today: LocalDate): List<RoutineItem>
     suspend fun setRoutineChecked(routineId: Int, date: LocalDate, isChecked: Boolean)
+    suspend fun getRoutineChecksForPeriod(startDate: LocalDate, endDate: LocalDate): List<RoutineCheck>
+    suspend fun getRoutineItemsForPeriod(startDate: LocalDate, endDate: LocalDate): List<RoutineItem>
+    fun isRoutineApplicableForDate(routine: RoutineItem, date: LocalDate): Boolean
 }
+
+
 
 

--- a/app/src/main/java/com/example/myroutine/data/repository/RoutineRepositoryImpl.kt
+++ b/app/src/main/java/com/example/myroutine/data/repository/RoutineRepositoryImpl.kt
@@ -71,20 +71,38 @@ class RoutineRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getRoutineItemsForPeriod(startDate: LocalDate, endDate: LocalDate): List<RoutineItem> {
-        val allRoutines = routineDao.getAll()
-        val routinesInPeriod = mutableListOf<RoutineItem>()
+        val routines = mutableListOf<RoutineItem>()
+        val addedRoutineIds = mutableSetOf<Int>()
         var currentDate = startDate
+
+        // 먼저 반복 없는 루틴들(특정 날짜) 한번에 가져오기
+        routines.addAll(routineDao.getNonRepeatingRoutinesInPeriod(startDate, endDate).also {
+            addedRoutineIds.addAll(it.map { r -> r.id })
+        })
+
+        // 기간 내 날짜별로 반복되는 루틴 쿼리 호출
         while (!currentDate.isAfter(endDate)) {
-            allRoutines.filter { routine ->
-                isRoutineApplicableForDate(routine, currentDate)
-            }.forEach { routine ->
-                if (!routinesInPeriod.any { it.id == routine.id }) {
-                    routinesInPeriod.add(routine)
+            // WEEKLY
+            routineDao.getWeeklyRoutinesByDate(currentDate).forEach { routine ->
+                if (addedRoutineIds.add(routine.id)) {
+                    routines.add(routine)
+                }
+            }
+            // EVERY_X_DAYS
+            routineDao.getEveryXDaysRoutinesByDate(currentDate).forEach { routine ->
+                if (addedRoutineIds.add(routine.id)) {
+                    routines.add(routine)
+                }
+            }
+            // WEEKDAY_HOLIDAY
+            routineDao.getWeekdayHolidayRoutinesByDate(currentDate).forEach { routine ->
+                if (addedRoutineIds.add(routine.id)) {
+                    routines.add(routine)
                 }
             }
             currentDate = currentDate.plusDays(1)
         }
-        return routinesInPeriod
+        return routines
     }
 
     override fun isRoutineApplicableForDate(routine: RoutineItem, date: LocalDate): Boolean {

--- a/app/src/main/java/com/example/myroutine/di/AppModule.kt
+++ b/app/src/main/java/com/example/myroutine/di/AppModule.kt
@@ -1,0 +1,18 @@
+package com.example.myroutine.di
+
+import com.example.myroutine.common.DateProvider
+import com.example.myroutine.common.DateProviderImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AppModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindDateProvider(impl: DateProviderImpl): DateProvider
+}

--- a/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
+++ b/app/src/main/java/com/example/myroutine/features/add/AddRoutineViewModel.kt
@@ -133,7 +133,7 @@ class AddRoutineViewModel @Inject constructor(
                 repeatDays = null
                 holidayType = null
                 repeatIntervalDays = null
-                startDate = null
+                startDate = LocalDate.now()
             }
             TAB_INDEX_WEEKLY -> {
                 repeatDays = _selectedDays.value
@@ -146,7 +146,7 @@ class AddRoutineViewModel @Inject constructor(
                 repeatType = if (_excludeHolidays.value) RepeatType.WEEKDAY_HOLIDAY else RepeatType.WEEKLY
                 holidayType = if (_excludeHolidays.value) HolidayType.WEEKDAY else null
                 repeatIntervalDays = null
-                startDate = null
+                startDate = LocalDate.now()
             }
             TAB_INDEX_EVERY_X_DAYS -> {
                 if (_repeatIntervalText.value.isBlank()) {

--- a/app/src/main/java/com/example/myroutine/features/report/ReportEvent.kt
+++ b/app/src/main/java/com/example/myroutine/features/report/ReportEvent.kt
@@ -1,0 +1,8 @@
+package com.example.myroutine.features.report
+
+import java.time.LocalDate
+
+sealed interface ReportEvent {
+    data class SelectDate(val date: LocalDate) : ReportEvent
+    data class SelectPeriod(val period: PeriodType) : ReportEvent
+}

--- a/app/src/main/java/com/example/myroutine/features/report/ReportScreen.kt
+++ b/app/src/main/java/com/example/myroutine/features/report/ReportScreen.kt
@@ -1,0 +1,136 @@
+package com.example.myroutine.features.report
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.myroutine.R
+
+@Composable
+fun ReportScreen(
+    viewModel: ReportViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsState()
+
+    Column(
+        modifier = Modifier.padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.report),
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Button(
+                modifier = Modifier.weight(1f),
+                onClick = { viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.WEEKLY)) },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (state.selectedPeriod == PeriodType.WEEKLY) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = if (state.selectedPeriod == PeriodType.WEEKLY) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            ) {
+                Text(
+                    text = stringResource(R.string.report_weekly),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
+            Button(
+                modifier = Modifier.weight(1f),
+                onClick = { viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.MONTHLY)) },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (state.selectedPeriod == PeriodType.MONTHLY) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = if (state.selectedPeriod == PeriodType.MONTHLY) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            ) {
+                Text(
+                    text = stringResource(R.string.report_monthly),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        ReportCard(
+            title = stringResource(R.string.report_completion_rate),
+            value = "${(state.completionRate * 100).toInt()}%"
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ReportCard(
+            title = stringResource(R.string.report_most_kept_routine),
+            value = if (state.mostKeptRoutine.isNotEmpty()) {
+                stringResource(R.string.report_most_kept_routine_with_count, state.mostKeptRoutine, state.mostKeptRoutineCount)
+            } else {
+                stringResource(R.string.report_na)
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ReportCard(
+            title = stringResource(R.string.report_most_missed_routine),
+            value = if (state.mostMissedRoutine.isNotEmpty()) {
+                stringResource(R.string.report_most_missed_routine_with_count, state.mostMissedRoutine, state.mostMissedRoutineCount)
+            } else {
+                stringResource(R.string.report_na)
+            }
+        )
+    }
+}
+
+@Composable
+fun ReportCard(title: String, value: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.Start
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground,
+                textAlign = TextAlign.Start
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = value,
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+                textAlign = TextAlign.Start
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/myroutine/features/report/ReportState.kt
+++ b/app/src/main/java/com/example/myroutine/features/report/ReportState.kt
@@ -1,0 +1,19 @@
+package com.example.myroutine.features.report
+
+import java.time.LocalDate
+
+enum class PeriodType {
+    WEEKLY,
+    MONTHLY
+}
+
+data class ReportState(
+    val selectedDate: LocalDate = LocalDate.now(),
+    val selectedPeriod: PeriodType = PeriodType.WEEKLY,
+    val completionRate: Float = 0f,
+    val mostKeptRoutine: String = "",
+    val mostKeptRoutineCount: Int = 0,
+    val mostMissedRoutine: String = "",
+    val mostMissedRoutineCount: Int = 0,
+    val isLoading: Boolean = false
+)

--- a/app/src/main/java/com/example/myroutine/features/report/ReportViewModel.kt
+++ b/app/src/main/java/com/example/myroutine/features/report/ReportViewModel.kt
@@ -1,0 +1,134 @@
+package com.example.myroutine.features.report
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.myroutine.common.DateProvider
+import com.example.myroutine.data.repository.RoutineRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import javax.inject.Inject
+
+@HiltViewModel
+class ReportViewModel @Inject constructor(
+    private val routineRepository: RoutineRepository,
+    private val dateProvider: DateProvider
+) : ViewModel() {
+    private val _state = MutableStateFlow(ReportState())
+    val state = _state.asStateFlow()
+
+    init {
+        calculateReportData()
+    }
+
+    fun onEvent(event: ReportEvent) {
+        when (event) {
+            is ReportEvent.SelectDate -> {
+                _state.update {
+                    it.copy(
+                        selectedDate = event.date
+                    )
+                }
+                calculateReportData()
+            }
+            is ReportEvent.SelectPeriod -> {
+                _state.update {
+                    it.copy(
+                        selectedPeriod = event.period
+                    )
+                }
+                calculateReportData()
+            }
+        }
+    }
+
+    private fun calculateReportData() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true) }
+
+            val selectedDate = _state.value.selectedDate
+            val selectedPeriod = _state.value.selectedPeriod
+
+            val startDate: LocalDate
+            val endDate: LocalDate
+
+            when (selectedPeriod) {
+                PeriodType.WEEKLY -> {
+                    startDate = selectedDate.with(java.time.DayOfWeek.MONDAY)
+                    endDate = selectedDate.with(java.time.DayOfWeek.SUNDAY)
+                }
+                PeriodType.MONTHLY -> {
+                    startDate = selectedDate.withDayOfMonth(1)
+                    endDate = selectedDate.withDayOfMonth(selectedDate.lengthOfMonth())
+                }
+            }
+
+            val allRoutines = routineRepository.getRoutines()
+            val routineChecks = routineRepository.getRoutineChecksForPeriod(startDate, endDate)
+
+            val expectedRoutineCounts = mutableMapOf<Int, Int>()
+            val completedRoutineCounts = mutableMapOf<Int, Int>()
+
+            var totalExpectedRoutines = 0
+            var totalCompletedRoutines = 0
+
+            var currentDate = startDate
+            val today = dateProvider.now() // LocalDate.now() 대신 dateProvider.now() 사용
+
+            while (!currentDate.isAfter(endDate) && !currentDate.isAfter(today)) { // 현재 날짜 이후는 계산에서 제외
+                val applicableRoutinesForDay = allRoutines.filter { routine ->
+                    routineRepository.isRoutineApplicableForDate(routine, currentDate)
+                }
+
+                val checkedRoutinesForDay = routineChecks.filter { it.completeDate == currentDate }
+
+                applicableRoutinesForDay.forEach { routine ->
+                    expectedRoutineCounts[routine.id] = (expectedRoutineCounts[routine.id] ?: 0) + 1
+                    totalExpectedRoutines++
+                }
+
+                checkedRoutinesForDay.forEach { check ->
+                    completedRoutineCounts[check.routineId] = (completedRoutineCounts[check.routineId] ?: 0) + 1
+                    totalCompletedRoutines++
+                }
+                currentDate = currentDate.plusDays(1)
+            }
+
+            val completionRate = if (totalExpectedRoutines > 0) {
+                totalCompletedRoutines.toFloat() / totalExpectedRoutines
+            } else {
+                0f
+            }
+
+            val mostKeptRoutine = completedRoutineCounts.maxByOrNull { it.value }?.key?.let { routineId ->
+                allRoutines.find { it.id == routineId }?.title
+            } ?: "N/A"
+
+            val mostKeptRoutineCount = completedRoutineCounts.maxByOrNull { it.value }?.value ?: 0
+
+            val mostMissedRoutine = expectedRoutineCounts.mapValues { (routineId, expectedCount) ->
+                expectedCount - (completedRoutineCounts[routineId] ?: 0)
+            }.maxByOrNull { it.value }?.key?.let { routineId ->
+                allRoutines.find { it.id == routineId }?.title
+            } ?: "N/A"
+
+            val mostMissedRoutineCount = expectedRoutineCounts.mapValues { (routineId, expectedCount) ->
+                expectedCount - (completedRoutineCounts[routineId] ?: 0)
+            }.maxByOrNull { it.value }?.value ?: 0
+
+            _state.update {
+                it.copy(
+                    completionRate = completionRate,
+                    mostKeptRoutine = mostKeptRoutine,
+                    mostKeptRoutineCount = mostKeptRoutineCount,
+                    mostMissedRoutine = mostMissedRoutine,
+                    mostMissedRoutineCount = mostMissedRoutineCount,
+                    isLoading = false
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -47,4 +47,12 @@
     <string name="calendar_year_month">%1$d년 %2$d월</string>
     <string name="calendar_routine_item">%1$d일 루틴 %2$d</string>
     <string name="calendar_select_date_message">날짜를 선택해 주세요.</string>
+    <string name="report_weekly">주간</string>
+    <string name="report_monthly">월간</string>
+    <string name="report_completion_rate">완료율</string>
+    <string name="report_most_kept_routine">가장 많이 지킨 루틴</string>
+    <string name="report_most_missed_routine">가장 많이 놓친 루틴</string>
+    <string name="report_na">해당 없음</string>
+    <string name="report_most_kept_routine_with_count">%1$s (%2$d회)</string>
+    <string name="report_most_missed_routine_with_count">%1$s (%2$d회)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,4 +46,12 @@
     <string name="calendar_year_month">%1$d-%2$d</string>
     <string name="calendar_routine_item">Routine %2$d for day %1$d</string>
     <string name="calendar_select_date_message">Please select a date.</string>
+    <string name="report_weekly">Weekly</string>
+    <string name="report_monthly">Monthly</string>
+    <string name="report_completion_rate">Completion Rate</string>
+    <string name="report_most_kept_routine">Most Kept Routine</string>
+    <string name="report_most_missed_routine">Most Missed Routine</string>
+    <string name="report_na">N/A</string>
+    <string name="report_most_kept_routine_with_count">%1$s (%2$d times)</string>
+    <string name="report_most_missed_routine_with_count">%1$s (%2$d times)</string>
 </resources>

--- a/app/src/test/java/com/example/myroutine/RoutineFilteringTest.kt
+++ b/app/src/test/java/com/example/myroutine/RoutineFilteringTest.kt
@@ -75,4 +75,23 @@ class RoutineFilteringTest {
         assertFalse(repository.isRoutineApplicableForDate(routine, saturday))
         assertFalse(repository.isRoutineApplicableForDate(routine, sunday))
     }
+
+    @Test
+    fun `isRoutineApplicableForDate should not apply weekly routine before its start date`() {
+        val startDate = LocalDate.of(2024, 7, 8) // Monday
+        val previousMonday = LocalDate.of(2024, 7, 1) // Previous Monday
+        val routine = RoutineItem.mock(
+            "Weekly Routine with Start Date",
+            repeatDays = listOf(DayOfWeek.MONDAY.value),
+            repeatType = RepeatType.WEEKLY,
+            startDate = startDate
+        )
+
+        // Should be applicable on or after startDate
+        assertTrue(repository.isRoutineApplicableForDate(routine, startDate))
+        assertTrue(repository.isRoutineApplicableForDate(routine, startDate.plusWeeks(1)))
+
+        // Should NOT be applicable before startDate, even if it's the correct day of week
+        assertFalse(repository.isRoutineApplicableForDate(routine, previousMonday))
+    }
 }

--- a/app/src/test/java/com/example/myroutine/data/repository/RoutineRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/myroutine/data/repository/RoutineRepositoryImplTest.kt
@@ -1,0 +1,98 @@
+package com.example.myroutine.data.repository
+
+import com.example.myroutine.data.local.dao.RoutineCheckDao
+import com.example.myroutine.data.local.dao.RoutineDao
+import com.example.myroutine.data.local.entity.RepeatType
+import com.example.myroutine.data.local.entity.RoutineCheck
+import com.example.myroutine.data.local.entity.RoutineItem
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * RoutineRepositoryImpl의 기능을 테스트하는 클래스입니다.
+ * Mockk 라이브러리를 사용하여 DAO(Data Access Object)를 목킹하고,
+ * kotlinx-coroutines-test를 사용하여 코루틴 테스트를 수행합니다.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RoutineRepositoryImplTest {
+
+    // 테스트 대상 Repository
+    private lateinit var repository: RoutineRepositoryImpl
+    // Mockk으로 생성된 RoutineDao 인스턴스
+    private val routineDao: RoutineDao = mockk()
+    // Mockk으로 생성된 RoutineCheckDao 인스턴스
+    private val checkDao: RoutineCheckDao = mockk()
+
+    /**
+     * 각 테스트 실행 전에 호출되는 초기화 함수입니다.
+     * - 목킹된 DAO를 사용하여 RoutineRepositoryImpl 인스턴스를 생성합니다.
+     */
+    @Before
+    fun setup() {
+        repository = RoutineRepositoryImpl(routineDao, checkDao)
+    }
+
+    /**
+     * getRoutineChecksForPeriod 메서드가 지정된 기간 내의 체크 기록을 올바르게 반환하는지 테스트합니다.
+     */
+    @Test
+    fun `getRoutineChecksForPeriod should return checks within the specified period`() = runTest {
+        // Given: 테스트를 위한 시작 날짜와 종료 날짜를 정의합니다.
+        val startDate = LocalDate.of(2024, 7, 1)
+        val endDate = LocalDate.of(2024, 7, 7)
+
+        // Given: 기간 내에 있는 가상의 루틴 체크 데이터와 기간 밖에 있는 데이터를 정의합니다.
+        val checksInPeriod = listOf(
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
+            RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 3)),
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 7))
+        )
+        val checksOutsidePeriod = listOf(
+            RoutineCheck(routineId = 3, completeDate = LocalDate.of(2024, 6, 30)),
+            RoutineCheck(routineId = 4, completeDate = LocalDate.of(2024, 7, 8))
+        )
+
+        // When: checkDao.getChecksForPeriod가 호출될 때, checksInPeriod를 반환하도록 목킹합니다.
+        coEvery { checkDao.getChecksForPeriod(startDate, endDate) } returns checksInPeriod
+
+        // Then: getRoutineChecksForPeriod를 호출하고 결과가 예상과 일치하는지 단언합니다.
+        val result = repository.getRoutineChecksForPeriod(startDate, endDate)
+        assertEquals(checksInPeriod.size, result.size)
+        assertEquals(checksInPeriod, result)
+    }
+
+    /**
+     * getRoutineItemsForPeriod 메서드가 지정된 기간 내에 적용 가능한 루틴을 올바르게 반환하는지 테스트합니다.
+     */
+    @Test
+    fun `getRoutineItemsForPeriod should return applicable routines within the period`() = runTest {
+        // Given: 테스트를 위한 시작 날짜와 종료 날짜를 정의합니다.
+        val startDate = LocalDate.of(2024, 7, 1) // 월요일
+        val endDate = LocalDate.of(2024, 7, 7) // 일요일
+
+        // Given: 가상의 루틴 데이터를 정의합니다.
+        val routine1 = RoutineItem.mock(id = 1, title = "Daily Routine") // 매일 적용 가능
+        val routine2 = RoutineItem.mock(id = 2, title = "Weekly Monday Routine", repeatType = RepeatType.WEEKLY, repeatDays = listOf(1)) // 월요일에만 적용 가능
+        val routine3 = RoutineItem.mock(id = 3, title = "Once on July 10", repeatType = RepeatType.ONCE, specificDate = LocalDate.of(2024, 7, 10)) // 기간 밖에 있는 루틴
+
+        // When: routineDao.getAll이 호출될 때, 모든 루틴을 반환하도록 목킹합니다.
+        coEvery { routineDao.getAll() } returns listOf(routine1, routine2, routine3)
+
+        // Then: getRoutineItemsForPeriod를 호출하고 결과가 예상과 일치하는지 단언합니다.
+        val result = repository.getRoutineItemsForPeriod(startDate, endDate)
+
+        // routine1은 포함되어야 합니다 (매일 적용 가능).
+        // routine2는 포함되어야 합니다 (7월 1일 월요일에 적용 가능).
+        // routine3은 제외되어야 합니다 (특정 날짜가 기간 밖에 있음).
+        assertEquals(2, result.size)
+        assert(result.contains(routine1))
+        assert(result.contains(routine2))
+        assert(!result.contains(routine3))
+    }
+}

--- a/app/src/test/java/com/example/myroutine/data/repository/RoutineRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/myroutine/data/repository/RoutineRepositoryImplTest.kt
@@ -44,7 +44,7 @@ class RoutineRepositoryImplTest {
      * getRoutineChecksForPeriod 메서드가 지정된 기간 내의 체크 기록을 올바르게 반환하는지 테스트합니다.
      */
     @Test
-    fun getRoutineChecksForPeriodShouldReturnChecksWithinTheSpecifiedPeriod() = runTest {
+    fun getRoutineChecksForPeriod_should_return_checks_within_the_specified_period() = runTest {
         // Given: 테스트를 위한 시작 날짜와 종료 날짜를 정의합니다.
         val startDate = LocalDate.of(2024, 7, 1)
         val endDate = LocalDate.of(2024, 7, 7)
@@ -73,7 +73,7 @@ class RoutineRepositoryImplTest {
      * getRoutineItemsForPeriod 메서드가 지정된 기간 내에 적용 가능한 루틴을 올바르게 반환하는지 테스트합니다.
      */
     @Test
-    fun getRoutineItemsForPeriodShouldReturnApplicableRoutinesWithinThePeriod() = runTest {
+    fun getRoutineItemsForPeriod_should_return_applicable_routines_within_the_period() = runTest {
         // Given: 테스트를 위한 시작 날짜와 종료 날짜를 정의합니다.
         val startDate = LocalDate.of(2024, 7, 1) // 월요일
         val endDate = LocalDate.of(2024, 7, 7) // 일요일

--- a/app/src/test/java/com/example/myroutine/data/repository/RoutineRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/myroutine/data/repository/RoutineRepositoryImplTest.kt
@@ -44,7 +44,7 @@ class RoutineRepositoryImplTest {
      * getRoutineChecksForPeriod 메서드가 지정된 기간 내의 체크 기록을 올바르게 반환하는지 테스트합니다.
      */
     @Test
-    fun `getRoutineChecksForPeriod should return checks within the specified period`() = runTest {
+    fun getRoutineChecksForPeriodShouldReturnChecksWithinTheSpecifiedPeriod() = runTest {
         // Given: 테스트를 위한 시작 날짜와 종료 날짜를 정의합니다.
         val startDate = LocalDate.of(2024, 7, 1)
         val endDate = LocalDate.of(2024, 7, 7)
@@ -73,7 +73,7 @@ class RoutineRepositoryImplTest {
      * getRoutineItemsForPeriod 메서드가 지정된 기간 내에 적용 가능한 루틴을 올바르게 반환하는지 테스트합니다.
      */
     @Test
-    fun `getRoutineItemsForPeriod should return applicable routines within the period`() = runTest {
+    fun getRoutineItemsForPeriodShouldReturnApplicableRoutinesWithinThePeriod() = runTest {
         // Given: 테스트를 위한 시작 날짜와 종료 날짜를 정의합니다.
         val startDate = LocalDate.of(2024, 7, 1) // 월요일
         val endDate = LocalDate.of(2024, 7, 7) // 일요일

--- a/app/src/test/java/com/example/myroutine/data/repository/RoutineRepositoryImplTest.kt
+++ b/app/src/test/java/com/example/myroutine/data/repository/RoutineRepositoryImplTest.kt
@@ -24,8 +24,10 @@ class RoutineRepositoryImplTest {
 
     // 테스트 대상 Repository
     private lateinit var repository: RoutineRepositoryImpl
+
     // Mockk으로 생성된 RoutineDao 인스턴스
     private val routineDao: RoutineDao = mockk()
+
     // Mockk으로 생성된 RoutineCheckDao 인스턴스
     private val checkDao: RoutineCheckDao = mockk()
 
@@ -77,15 +79,34 @@ class RoutineRepositoryImplTest {
         val endDate = LocalDate.of(2024, 7, 7) // 일요일
 
         // Given: 가상의 루틴 데이터를 정의합니다.
-        val routine1 = RoutineItem.mock(id = 1, title = "Daily Routine") // 매일 적용 가능
-        val routine2 = RoutineItem.mock(id = 2, title = "Weekly Monday Routine", repeatType = RepeatType.WEEKLY, repeatDays = listOf(1)) // 월요일에만 적용 가능
-        val routine3 = RoutineItem.mock(id = 3, title = "Once on July 10", repeatType = RepeatType.ONCE, specificDate = LocalDate.of(2024, 7, 10)) // 기간 밖에 있는 루틴
+        val routine1 = RoutineItem.mock(
+            id = 1,
+            title = "Daily Routine",
+            repeatType = RepeatType.EVERY_X_DAYS,
+            repeatIntervalDays = 1,
+            startDate = LocalDate.of(2024, 7, 1)  // 시작일도 명시해주는 게 좋아요
+        ) // 매일 적용 가능
+        val routine2 = RoutineItem.mock(
+            id = 2,
+            title = "Weekly Monday Routine",
+            repeatType = RepeatType.WEEKLY,
+            repeatDays = listOf(1)
+        ) // 월요일에만 적용 가능
+        val routine3 = RoutineItem.mock(
+            id = 3,
+            title = "Once on July 10",
+            repeatType = RepeatType.ONCE,
+            specificDate = LocalDate.of(2024, 7, 10)
+        ) // 기간 밖에 있는 루틴
 
         // When: routineDao.getAll이 호출될 때, 모든 루틴을 반환하도록 목킹합니다.
         coEvery { routineDao.getAll() } returns listOf(routine1, routine2, routine3)
 
         // Then: getRoutineItemsForPeriod를 호출하고 결과가 예상과 일치하는지 단언합니다.
         val result = repository.getRoutineItemsForPeriod(startDate, endDate)
+
+        println("Result routines:")
+        result.forEach { println("- ${it.title} (id=${it.id})") }
 
         // routine1은 포함되어야 합니다 (매일 적용 가능).
         // routine2는 포함되어야 합니다 (7월 1일 월요일에 적용 가능).

--- a/app/src/test/java/com/example/myroutine/features/report/ReportViewModelTest.kt
+++ b/app/src/test/java/com/example/myroutine/features/report/ReportViewModelTest.kt
@@ -30,114 +30,124 @@ class ReportViewModelTest {
     private val dateProvider: DateProvider = mockk()
     private val testDispatcher = StandardTestDispatcher()
 
+    // 공통 루틴 데이터 (테스트에서 재사용)
+    private val routine1 = RoutineItem.mock(id = 1, title = "Routine A")
+    private val routine2 = RoutineItem.mock(id = 2, title = "Routine B")
+    private val routine3 = RoutineItem.mock(id = 3, title = "Routine C")
+
     @Before
     fun setup() {
+        // Main dispatcher를 테스트용 디스패처로 설정
         Dispatchers.setMain(testDispatcher)
 
-        val routine1 = RoutineItem.mock(id = 1, title = "Routine A")
-        val routine2 = RoutineItem.mock(id = 2, title = "Routine B")
-        val routine3 = RoutineItem.mock(id = 3, title = "Routine C")
-
+        // 기본 루틴 리스트 반환 세팅 (변경 없으면 공통 사용)
         coEvery { routineRepository.getRoutines() } returns listOf(routine1, routine2, routine3)
+
+        // isRoutineApplicableForDate 기본 true 반환 (필요시 개별 테스트에서 수정 가능)
         coEvery { routineRepository.isRoutineApplicableForDate(any(), any()) } returns true
+
+        // dateProvider.now() 기본값 세팅
         coEvery { dateProvider.now() } returns LocalDate.of(2024, 7, 7)
 
-        coEvery { routineRepository.getRoutineChecksForPeriod(LocalDate.of(2025, 7, 7), LocalDate.of(2025, 7, 13)) } returns listOf(
-            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2025, 7, 7)),
-            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2025, 7, 8)),
-            RoutineCheck(routineId = 2, completeDate = LocalDate.of(2025, 7, 7))
-        )
-
+        // 뷰모델 초기화
         viewModel = ReportViewModel(routineRepository, dateProvider)
+    }
+
+    /**
+     * 테스트용 RoutineCheck 목록 목킹 헬퍼 함수
+     */
+    private fun mockRoutineChecks(checks: List<RoutineCheck>) {
+        coEvery { routineRepository.getRoutineChecksForPeriod(any(), any()) } returns checks
+    }
+
+    /**
+     * 날짜와 기간을 선택하고, 이벤트를 전달하는 헬퍼 함수
+     */
+    private suspend fun selectDateAndPeriod(date: LocalDate, period: PeriodType) {
+        viewModel.onEvent(ReportEvent.SelectDate(date))
+        viewModel.onEvent(ReportEvent.SelectPeriod(period))
     }
 
     @Test
     fun calculateReportData_should_correctly_calculate_completion_rate() = runTest {
-        val checks = listOf(
-            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
-            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
-            RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 1))
+        // 완료 체크 데이터를 목킹
+        mockRoutineChecks(
+            listOf(
+                RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
+                RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
+                RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 1))
+            )
         )
-        coEvery { routineRepository.getRoutineChecksForPeriod(any(), any()) } returns checks
-
-        viewModel.onEvent(ReportEvent.SelectDate(LocalDate.of(2024,7,7)))  // 선택 날짜 이벤트로 재계산 유도
-        viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.WEEKLY))
-
+        // 날짜와 기간 선택 이벤트 발생
+        selectDateAndPeriod(LocalDate.of(2024,7,7), PeriodType.WEEKLY)
+        // 모든 코루틴 작업 완료 대기
         advanceUntilIdle()
 
         val state = viewModel.state.first()
-
-        println("=== Test: Completion Rate ===")
-        println("Expected Total Expected Routines: 21 (3 routines * 7 days)")
-        println("Expected Total Completed Routines: ${checks.size}")
-        println("Calculated completionRate: ${state.completionRate}")
-        println("Most kept routine: ${state.mostKeptRoutine} (${state.mostKeptRoutineCount})")
-        println("Most missed routine: ${state.mostMissedRoutine} (${state.mostMissedRoutineCount})")
-
+        // 예상 완료율 검증
         assertEquals(1f / 7f, state.completionRate, 0.001f)
     }
 
     @Test
     fun calculateReportData_should_correctly_identify_most_kept_routine() = runTest {
-        val checks = listOf(
-            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
-            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
-            RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 1))
+        mockRoutineChecks(
+            listOf(
+                RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
+                RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
+                RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 1))
+            )
         )
-        coEvery { routineRepository.getRoutineChecksForPeriod(any(), any()) } returns checks
-
-        viewModel.onEvent(ReportEvent.SelectDate(LocalDate.of(2024,7,7)))
-        viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.WEEKLY))
-
+        selectDateAndPeriod(LocalDate.of(2024,7,7), PeriodType.WEEKLY)
         advanceUntilIdle()
 
         val state = viewModel.state.first()
+        // 가장 많이 수행한 루틴 이름과 횟수 검증
         assertEquals("Routine A", state.mostKeptRoutine)
         assertEquals(2, state.mostKeptRoutineCount)
     }
 
     @Test
     fun calculateReportData_should_correctly_identify_most_missed_routine() = runTest {
-        val checks = listOf(
-            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
-            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
-            RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 1))
+        mockRoutineChecks(
+            listOf(
+                RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
+                RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
+                RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 1))
+            )
         )
-        coEvery { routineRepository.getRoutineChecksForPeriod(any(), any()) } returns checks
-
-        viewModel.onEvent(ReportEvent.SelectDate(LocalDate.of(2024,7,7)))
-        viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.WEEKLY))
-
+        selectDateAndPeriod(LocalDate.of(2024,7,7), PeriodType.WEEKLY)
         advanceUntilIdle()
 
         val state = viewModel.state.first()
+        // 가장 많이 놓친 루틴 이름과 횟수 검증
         assertEquals("Routine C", state.mostMissedRoutine)
         assertEquals(7, state.mostMissedRoutineCount)
     }
 
     @Test
     fun calculateReportData_should_exclude_future_dates_from_calculation() = runTest {
+        // 현재 날짜를 테스트용으로 변경
         val testToday = LocalDate.of(2024, 6, 15)
         coEvery { dateProvider.now() } returns testToday
 
-        val routine1 = RoutineItem.mock(id = 1, title = "Routine A")
-        val routine2 = RoutineItem.mock(id = 2, title = "Routine B")
+        val routineA = RoutineItem.mock(id = 1, title = "Routine A")
+        val routineB = RoutineItem.mock(id = 2, title = "Routine B")
 
         val checks = listOf(
             RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 6, 15))
         )
 
-        coEvery { routineRepository.getRoutines() } returns listOf(routine1, routine2)
+        // 테스트용 루틴과 체크 데이터 목킹
+        coEvery { routineRepository.getRoutines() } returns listOf(routineA, routineB)
         coEvery { routineRepository.getRoutineChecksForPeriod(any(), any()) } returns checks
         coEvery { routineRepository.isRoutineApplicableForDate(any(), any()) } returns true
 
         viewModel = ReportViewModel(routineRepository, dateProvider)
-        viewModel.onEvent(ReportEvent.SelectDate(LocalDate.of(2024, 6, 10)))
-        viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.WEEKLY))
-
+        selectDateAndPeriod(LocalDate.of(2024, 6, 10), PeriodType.WEEKLY)
         advanceUntilIdle()
 
         val state = viewModel.state.first()
+        // 미래 날짜 제외 후 완료율 검증
         assertEquals(1f / 12f, state.completionRate, 0.001f)
     }
 
@@ -149,13 +159,13 @@ class ReportViewModelTest {
             RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
             RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 15))
         )
-        coEvery { routineRepository.getRoutineChecksForPeriod(any(), any()) } returns monthlyChecks
+        mockRoutineChecks(monthlyChecks)
 
-        viewModel.onEvent(ReportEvent.SelectDate(LocalDate.of(2024, 7, 15))) // 추가: 날짜 선택 이벤트 먼저
-        viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.MONTHLY))
+        selectDateAndPeriod(LocalDate.of(2024, 7, 15), PeriodType.MONTHLY)
         advanceUntilIdle()
 
         val state = viewModel.state.first()
+        // 월별 완료율 검증
         assertEquals(2f / 45f, state.completionRate, 0.001f)
     }
 }

--- a/app/src/test/java/com/example/myroutine/features/report/ReportViewModelTest.kt
+++ b/app/src/test/java/com/example/myroutine/features/report/ReportViewModelTest.kt
@@ -63,7 +63,7 @@ class ReportViewModelTest {
     /**
      * 날짜와 기간을 선택하고, 이벤트를 전달하는 헬퍼 함수
      */
-    private suspend fun selectDateAndPeriod(date: LocalDate, period: PeriodType) {
+    private fun selectDateAndPeriod(date: LocalDate, period: PeriodType) {
         viewModel.onEvent(ReportEvent.SelectDate(date))
         viewModel.onEvent(ReportEvent.SelectPeriod(period))
     }

--- a/app/src/test/java/com/example/myroutine/features/report/ReportViewModelTest.kt
+++ b/app/src/test/java/com/example/myroutine/features/report/ReportViewModelTest.kt
@@ -1,0 +1,161 @@
+package com.example.myroutine.features.report
+
+import com.example.myroutine.common.DateProvider
+import com.example.myroutine.data.local.entity.RoutineCheck
+import com.example.myroutine.data.local.entity.RoutineItem
+import com.example.myroutine.data.repository.RoutineRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+
+/**
+ * ReportViewModel 테스트 클래스
+ * Mockk로 Repository를 목킹하고 kotlinx-coroutines-test로 코루틴 테스트 수행
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReportViewModelTest {
+
+    private lateinit var viewModel: ReportViewModel
+    private val routineRepository: RoutineRepository = mockk()
+    private val dateProvider: DateProvider = mockk()
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+
+        val routine1 = RoutineItem.mock(id = 1, title = "Routine A")
+        val routine2 = RoutineItem.mock(id = 2, title = "Routine B")
+        val routine3 = RoutineItem.mock(id = 3, title = "Routine C")
+
+        coEvery { routineRepository.getRoutines() } returns listOf(routine1, routine2, routine3)
+        coEvery { routineRepository.isRoutineApplicableForDate(any(), any()) } returns true
+        coEvery { dateProvider.now() } returns LocalDate.of(2024, 7, 7)
+
+        coEvery { routineRepository.getRoutineChecksForPeriod(LocalDate.of(2025, 7, 7), LocalDate.of(2025, 7, 13)) } returns listOf(
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2025, 7, 7)),
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2025, 7, 8)),
+            RoutineCheck(routineId = 2, completeDate = LocalDate.of(2025, 7, 7))
+        )
+
+        viewModel = ReportViewModel(routineRepository, dateProvider)
+    }
+
+    @Test
+    fun `calculateReportData should correctly calculate completion rate`() = runTest {
+        val checks = listOf(
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
+            RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 1))
+        )
+        coEvery { routineRepository.getRoutineChecksForPeriod(any(), any()) } returns checks
+
+        viewModel.onEvent(ReportEvent.SelectDate(LocalDate.of(2024,7,7)))  // 선택 날짜 이벤트로 재계산 유도
+        viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.WEEKLY))
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.first()
+
+        println("=== Test: Completion Rate ===")
+        println("Expected Total Expected Routines: 21 (3 routines * 7 days)")
+        println("Expected Total Completed Routines: ${checks.size}")
+        println("Calculated completionRate: ${state.completionRate}")
+        println("Most kept routine: ${state.mostKeptRoutine} (${state.mostKeptRoutineCount})")
+        println("Most missed routine: ${state.mostMissedRoutine} (${state.mostMissedRoutineCount})")
+
+        assertEquals(1f / 7f, state.completionRate, 0.001f)
+    }
+
+    @Test
+    fun `calculateReportData should correctly identify most kept routine`() = runTest {
+        val checks = listOf(
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
+            RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 1))
+        )
+        coEvery { routineRepository.getRoutineChecksForPeriod(any(), any()) } returns checks
+
+        viewModel.onEvent(ReportEvent.SelectDate(LocalDate.of(2024,7,7)))
+        viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.WEEKLY))
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.first()
+        assertEquals("Routine A", state.mostKeptRoutine)
+        assertEquals(2, state.mostKeptRoutineCount)
+    }
+
+    @Test
+    fun `calculateReportData should correctly identify most missed routine`() = runTest {
+        val checks = listOf(
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
+            RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 1))
+        )
+        coEvery { routineRepository.getRoutineChecksForPeriod(any(), any()) } returns checks
+
+        viewModel.onEvent(ReportEvent.SelectDate(LocalDate.of(2024,7,7)))
+        viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.WEEKLY))
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.first()
+        assertEquals("Routine C", state.mostMissedRoutine)
+        assertEquals(7, state.mostMissedRoutineCount)
+    }
+
+    @Test
+    fun `calculateReportData should exclude future dates from calculation`() = runTest {
+        val testToday = LocalDate.of(2024, 6, 15)
+        coEvery { dateProvider.now() } returns testToday
+
+        val routine1 = RoutineItem.mock(id = 1, title = "Routine A")
+        val routine2 = RoutineItem.mock(id = 2, title = "Routine B")
+
+        val checks = listOf(
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 6, 15))
+        )
+
+        coEvery { routineRepository.getRoutines() } returns listOf(routine1, routine2)
+        coEvery { routineRepository.getRoutineChecksForPeriod(any(), any()) } returns checks
+        coEvery { routineRepository.isRoutineApplicableForDate(any(), any()) } returns true
+
+        viewModel = ReportViewModel(routineRepository, dateProvider)
+        viewModel.onEvent(ReportEvent.SelectDate(LocalDate.of(2024, 6, 10)))
+        viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.WEEKLY))
+
+        advanceUntilIdle()
+
+        val state = viewModel.state.first()
+        assertEquals(1f / 12f, state.completionRate, 0.001f)
+    }
+
+    @Test
+    fun `onEvent SelectPeriod should trigger data recalculation`() = runTest {
+        coEvery { dateProvider.now() } returns LocalDate.of(2024, 7, 15)
+
+        val monthlyChecks = listOf(
+            RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
+            RoutineCheck(routineId = 2, completeDate = LocalDate.of(2024, 7, 15))
+        )
+        coEvery { routineRepository.getRoutineChecksForPeriod(any(), any()) } returns monthlyChecks
+
+        viewModel.onEvent(ReportEvent.SelectDate(LocalDate.of(2024, 7, 15))) // 추가: 날짜 선택 이벤트 먼저
+        viewModel.onEvent(ReportEvent.SelectPeriod(PeriodType.MONTHLY))
+        advanceUntilIdle()
+
+        val state = viewModel.state.first()
+        assertEquals(2f / 45f, state.completionRate, 0.001f)
+    }
+}

--- a/app/src/test/java/com/example/myroutine/features/report/ReportViewModelTest.kt
+++ b/app/src/test/java/com/example/myroutine/features/report/ReportViewModelTest.kt
@@ -52,7 +52,7 @@ class ReportViewModelTest {
     }
 
     @Test
-    fun `calculateReportData should correctly calculate completion rate`() = runTest {
+    fun calculateReportData_should_correctly_calculate_completion_rate() = runTest {
         val checks = listOf(
             RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
             RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
@@ -78,7 +78,7 @@ class ReportViewModelTest {
     }
 
     @Test
-    fun `calculateReportData should correctly identify most kept routine`() = runTest {
+    fun calculateReportData_should_correctly_identify_most_kept_routine() = runTest {
         val checks = listOf(
             RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
             RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
@@ -97,7 +97,7 @@ class ReportViewModelTest {
     }
 
     @Test
-    fun `calculateReportData should correctly identify most missed routine`() = runTest {
+    fun calculateReportData_should_correctly_identify_most_missed_routine() = runTest {
         val checks = listOf(
             RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 1)),
             RoutineCheck(routineId = 1, completeDate = LocalDate.of(2024, 7, 2)),
@@ -116,7 +116,7 @@ class ReportViewModelTest {
     }
 
     @Test
-    fun `calculateReportData should exclude future dates from calculation`() = runTest {
+    fun calculateReportData_should_exclude_future_dates_from_calculation() = runTest {
         val testToday = LocalDate.of(2024, 6, 15)
         coEvery { dateProvider.now() } returns testToday
 
@@ -142,7 +142,7 @@ class ReportViewModelTest {
     }
 
     @Test
-    fun `onEvent SelectPeriod should trigger data recalculation`() = runTest {
+    fun onEvent_SelectPeriod_should_trigger_data_recalculation() = runTest {
         coEvery { dateProvider.now() } returns LocalDate.of(2024, 7, 15)
 
         val monthlyChecks = listOf(


### PR DESCRIPTION
# PR 요약

이번 PR은 새로운 리포팅 기능을 도입하고, 루틴 필터링 로직을 개선했으며, 날짜 처리에 대한 의존성 주입을 추가한 작업입니다. 주요 변경 사항은 `ReportScreen` 및 관련 클래스 추가, 기간 기반 데이터 조회를 위한 저장소 메서드 업데이트, 시작일이 있는 주간 루틴 필터링 로직 조정 등입니다.
<img src="https://github.com/user-attachments/assets/1f599318-ca64-4dbb-9965-b05ddb937235" alt="Screenshot" width="300"/>

---

## 리포팅 기능

- **새로운 `ReportScreen` 및 관련 클래스 추가**  
  주간/월간 뷰를 제공하는 리포팅 UI 및 기능 추가 (`ReportScreen`, `ReportEvent`, `ReportState`, `ReportViewModel`). 완료율, 가장 잘 지킨 루틴, 가장 놓친 루틴 등을 보여줍니다.

- **로컬라이즈된 문자열 추가**  
  리포팅 기능에 필요한 영어 및 한국어 문자열 리소스 추가.

---

## 루틴 필터링 로직

- **루틴 적용 조건 개선**  
  시작일이 있는 주간 반복 루틴이 시작일 이전에는 적용되지 않도록 `isRoutineApplicableForDate` 로직 업데이트.

- **단위 테스트 추가**  
  시작일이 있는 주간 루틴 필터링 로직을 검증하는 테스트 코드 추가.

---

## 저장소 기능 개선

- **기간 기반 데이터 조회 기능 추가**  
  특정 기간 내 루틴 체크 및 루틴 아이템을 조회하는 메서드를 `RoutineRepository` 및 구현체에 추가.

---

## 의존성 주입

- **날짜 처리 추상화 도입**  
  `DateProvider` 인터페이스와 구현체(`DateProviderImpl`)를 생성하고, Dagger Hilt를 통해 의존성 주입하도록 통합.

---

## 기타 업데이트

- **기본 시작일 설정**  
  `AddRoutineViewModel`에서 주간 및 인터벌 반복 루틴에 기본 시작일을 현재 날짜로 설정하도록 변경.

---
closes #10